### PR TITLE
Fix manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-csi-snapshot-controller-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-csi-snapshot-controller-operator

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-csi-snapshot-controller-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-csi-snapshot-controller-operator

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-csi-snapshot-controller-operator
+  name: openshift-csi-snapshot-controller-operator-config
+data:
+  operator-config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/manifests/05_operator_rbac.yaml
+++ b/manifests/05_operator_rbac.yaml
@@ -1,42 +1,3 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  # rename if there are conflicts
-  name: csi-snapshot-controller-operator-runner
-  namespace: openshift-csi-snapshot-controller-operator
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots/status"]
-    verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete", "get", "update"]
-
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -47,41 +8,8 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
   - kind: ServiceAccount
-    name: csi-snapshot-controller
-    namespace: openshift-csi-snapshot-controller-operator
-roleRef:
-  kind: ClusterRole
-  # change the name also here if the ClusterRole gets renamed
-  name: csi-snapshot-controller-operator-runner
-  apiGroup: rbac.authorization.k8s.io
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-snapshot-controller-operator-leaderelection
-  namespace: openshift-csi-snapshot-controller-operator
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-snapshot-controller-operator-leaderelection
-  namespace: openshift-csi-snapshot-controller-operator
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-subjects:
-  - kind: ServiceAccount
     name: csi-snapshot-controller-operator
     namespace: openshift-csi-snapshot-controller-operator
 roleRef:
-  kind: Role
-  name: csi-snapshot-controller-operator-leaderelection
-  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/manifests/08_deployment.yaml
+++ b/manifests/08_deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-csi-snapshot-controller-operator
+  name: csi-snapshot-controller-operator
+  labels:
+    app: csi-snapshot-controller-operator
+  annotations:
+    config.openshift.io/inject-proxy: operator
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-snapshot-controller-operator
+  template:
+    metadata:
+      name: csi-snapshot-controller-operator
+      labels:
+        app: csi-snapshot-controller-operator
+    spec:
+      serviceAccountName: csi-snapshot-controller-operator
+      containers:
+      - name: operator
+        # TODO: fix to official image
+        image: quay.io/jsafrane/csi-snapshot-operator:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+        args: [ "start", "-v", "5" , "--config=/var/run/configmaps/config/operator-config.yaml"]
+        env:
+        - name: IMAGE
+          value: quay.io/k8scsi/snapshot-controller:v2.0.0
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snapshot"
+        - name: OPERAND_IMAGE_VERSION
+          value: "0.0.1-snapshot_openshift"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+      volumes:
+      - name: config
+        configMap:
+          defaultMode: 440
+          name: openshift-csi-snapshot-controller-operator-config
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120


### PR DESCRIPTION
 Add manifests to work in-cluster

- Using "admin" role for the operator - the operator reads various secrets from kube-system. It's commonly used in all other operators.
- Adding operator deployment.
- Adding config-map for configuration override, as it seems to be common in OpenShift.
- Use Go 1.13 for images