### PR TITLE
Included creation of csi-snapshot-controller deployment

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -2,6 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-snapshot-controller
+  namespace: openshift-csi-snapshot-controller
 spec:
   serviceName: "csi-snapshot-controller"
   replicas: 1

--- a/pkg/common/builder.go
+++ b/pkg/common/builder.go
@@ -5,6 +5,7 @@ import (
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
@@ -24,6 +25,11 @@ func (cb *Builder) APIExtClientOrDie(name string) apiext.Interface {
 // KubeClientOrDie returns the kubernetes client interface for general kubernetes objects.
 func (cb *Builder) KubeClientOrDie(name string) kubernetes.Interface {
 	return kubernetes.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
+}
+
+// AppClientOrDie returns the kubernetes client interface for application kubernetes objects
+func (cb *Builder) AppClientOrDie(name string) appsclientv1.AppsV1Interface {
+	return appsclientv1.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
 }
 
 // NewBuilder returns a *ClientBuilder with the given kubeconfig.

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -52,6 +52,7 @@ var _csi_controller_deploymentYaml = []byte(`kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-snapshot-controller
+  namespace: openshift-csi-snapshot-controller
 spec:
   serviceName: "csi-snapshot-controller"
   replicas: 1

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -12,7 +12,10 @@ import (
 	apiextlistersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	appslisterv1 "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/workqueue"
@@ -70,6 +73,10 @@ type csiSnapshotOperator struct {
 	crdListerSyncer cache.InformerSynced
 	crdClient       apiextclient.Interface
 
+	deployLister       appslisterv1.DeploymentLister
+	deployListerSynced cache.InformerSynced
+	deployClient       appsclientv1.AppsV1Interface
+
 	queue workqueue.RateLimitingInterface
 
 	stopCh <-chan struct{}
@@ -79,6 +86,8 @@ func NewCSISnapshotControllerOperator(
 	client OperatorClient,
 	crdInformer apiextinformersv1beta1.CustomResourceDefinitionInformer,
 	crdClient apiextclient.Interface,
+	deployInformer appsinformersv1.DeploymentInformer,
+	deployClient appsclientv1.AppsV1Interface,
 	kubeClient kubernetes.Interface,
 	versionGetter status.VersionGetter,
 	eventRecorder events.Recorder,
@@ -86,6 +95,7 @@ func NewCSISnapshotControllerOperator(
 	csiOperator := &csiSnapshotOperator{
 		client:        client,
 		crdClient:     crdClient,
+		deployClient:  deployClient,
 		kubeClient:    kubeClient,
 		versionGetter: versionGetter,
 		eventRecorder: eventRecorder,
@@ -103,6 +113,9 @@ func NewCSISnapshotControllerOperator(
 
 	csiOperator.crdLister = crdInformer.Lister()
 	csiOperator.crdListerSyncer = crdInformer.Informer().HasSynced
+
+	csiOperator.deployLister = deployInformer.Lister()
+	csiOperator.deployListerSynced = deployInformer.Informer().HasSynced
 
 	csiOperator.vStore.Set("operator", os.Getenv("RELEASE_VERSION"))
 
@@ -197,6 +210,9 @@ func (c *csiSnapshotOperator) updateSyncError(status *operatorv1.OperatorStatus,
 func (c *csiSnapshotOperator) handleSync(instance *operatorv1.CSISnapshotController) error {
 	if err := c.syncCustomResourceDefinitions(); err != nil {
 		return fmt.Errorf("failed to sync CRDs: %s", err)
+	}
+	if err := c.syncDeployments(); err != nil {
+		return fmt.Errorf("failed to sync Deployments: %s", err)
 	}
 	if err := c.syncStatus(instance); err != nil {
 		return fmt.Errorf("failed to sync status: %s", err)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -59,6 +59,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		*operatorClient,
 		ctrlctx.APIExtInformerFactory.Apiextensions().V1beta1().CustomResourceDefinitions(),
 		ctrlctx.ClientBuilder.APIExtClientOrDie(targetName),
+		ctrlctx.KubeNamespacedInformerFactory.Apps().V1().Deployments(),
+		ctrlctx.ClientBuilder.AppClientOrDie(targetName),
 		ctrlctx.ClientBuilder.KubeClientOrDie(targetName),
 		versionGetter,
 		controllerConfig.EventRecorder,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -17,7 +19,12 @@ var crds = [...]string{"volumesnapshots.yaml",
 	"volumesnapshotcontents.yaml",
 	"volumesnapshotclasses.yaml"}
 
+var deployment = "csi_controller_deployment.yaml"
+
 const (
+	deploymentRolloutPollInterval = time.Second
+	deploymentRolloutTimeout      = 10 * time.Minute
+
 	customResourceReadyInterval = time.Second
 	customResourceReadyTimeout  = 10 * time.Minute
 )
@@ -57,6 +64,54 @@ func (c *csiSnapshotOperator) waitForCustomResourceDefinition(resource *apiextv1
 	}); err != nil {
 		if err == wait.ErrWaitTimeout {
 			return fmt.Errorf("%v during syncCustomResourceDefinitions: %v", err, lastErr)
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *csiSnapshotOperator) syncDeployments() error {
+	deploy := resourceread.ReadDeploymentV1OrDie(generated.MustAsset(deployment))
+	_, updated, err := resourceapply.ApplyDeployment(c.deployClient, c.eventRecorder, deploy, 0, true)
+	if err != nil {
+		return err
+	}
+	if updated {
+		if err := c.waitForDeploymentRollout(deploy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//nolint:dupl
+func (c *csiSnapshotOperator) waitForDeploymentRollout(resource *appsv1.Deployment) error {
+	var lastErr error
+	if err := wait.Poll(deploymentRolloutPollInterval, deploymentRolloutTimeout, func() (bool, error) {
+		d, err := c.deployLister.Deployments(resource.Namespace).Get(resource.Name)
+		if apierrors.IsNotFound(err) {
+			// exit early to recreate the deployment.
+			return false, err
+		}
+		if err != nil {
+			// Do not return error here, as we could be updating the API Server itself, in which case we
+			// want to continue waiting.
+			lastErr = fmt.Errorf("error getting Deployment %s during rollout: %v", resource.Name, err)
+			return false, nil
+		}
+
+		if d.DeletionTimestamp != nil {
+			return false, fmt.Errorf("Deployment %s is being deleted", resource.Name)
+		}
+
+		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedReplicas == d.Status.Replicas && d.Status.UnavailableReplicas == 0 {
+			return true, nil
+		}
+		lastErr = fmt.Errorf("Deployment %s is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
+		return false, nil
+	}); err != nil {
+		if err == wait.ErrWaitTimeout {
+			return fmt.Errorf("%v during waitForDeploymentRollout: %v", err, lastErr)
 		}
 		return err
 	}


### PR DESCRIPTION
This allows the csi-snapshot-controller-operator to create and monitor the csi-snapshot-controller deployment.

I've tested this on a 4.2 cluster, and it has the same issue that the CRD one did - it will constantly update the deployment; however, it does deploy and manage it.