### PR TITLE
Add version to CSISnapshotController.Status and ClusterOperator

### DIFF
--- a/manifests/08_deployment.yaml
+++ b/manifests/08_deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERAND_IMAGE_VERSION
-          value: "0.0.1-snapshot_openshift"
+          value: "0.0.1-snapshot"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -52,6 +52,7 @@ var (
 	csiSnapshotControllerImage = os.Getenv(targetNameController)
 
 	operatorVersion = os.Getenv(operatorVersionEnvName)
+	operandVersion  = os.Getenv(operandVersionEnvName)
 
 	crdNames = []string{"volumesnapshotclasses.snapshot.storage.k8s.io", "volumesnapshotcontents.snapshot.storage.k8s.io", "volumesnapshots.snapshot.storage.k8s.io"}
 )
@@ -230,7 +231,18 @@ func (c *csiSnapshotOperator) syncStatus(instance *operatorv1.CSISnapshotControl
 			Type:   operatorv1.OperatorStatusTypeProgressing,
 			Status: operatorv1.ConditionFalse,
 		})
+
+	c.setVersion("operator", operatorVersion)
+	// TODO: check which version to report when the Deployment is being updated
+	c.setVersion("csi-snapshot-controller", operandVersion)
+
 	return nil
+}
+
+func (c *csiSnapshotOperator) setVersion(operandName, version string) {
+	if c.versionGetter.GetVersions()[operandName] != version {
+		c.versionGetter.SetVersion(operandName, version)
+	}
 }
 
 func (c *csiSnapshotOperator) enqueue(obj interface{}) {


### PR DESCRIPTION
With this PR, ClusterOperator.Status.Versions are filled:
```
  versions:
  - name: operator
    version: 4.4.0-0.okd-2020-01-20-000453
  - name: csi-snapshot-controller
    version: 4.4.0-0.okd-2020-01-20-000453
```