### PR TITLE
Make the controller (operand) critical

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -22,3 +22,13 @@ spec:
             - "--v=5"
             - "--leader-election=true"
           imagePullPolicy: Always
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -71,7 +71,18 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=true"
-          imagePullPolicy: Always`)
+          imagePullPolicy: Always
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+`)
 
 func csi_controller_deploymentYamlBytes() ([]byte, error) {
 	return _csi_controller_deploymentYaml, nil


### PR DESCRIPTION
So it's not evicted from nodes. We need it running in a cluster, the same way as the operator.