### PR TITLE
Fix operator version name

### DIFF
--- a/manifests/08_clusteroperator.yaml
+++ b/manifests/08_clusteroperator.yaml
@@ -1,4 +1,3 @@
-# TODO: check if this is necessary
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
@@ -7,8 +6,8 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 status:
   versions:
-  - name: csi-snapshot-controller-operator
+  - name: operator
     version: "0.0.1-snapshot"
   - name: csi-snapshot-controller
-    version: "0.0.1-snapshot_openshift"
+    version: "0.0.1-snapshot"
 spec: {}


### PR DESCRIPTION
To be in sync with code in sync.go. This should fix cluster installation, when CVO was waiting for version of `csi-snapshot-controller-operator`, while the operator reported its version as `operator`.