### PR TITLE
Force update Deployment when CSISnapshotController.LogLevel is changed

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -72,12 +72,20 @@ func (c *csiSnapshotOperator) waitForCustomResourceDefinition(resource *apiextv1
 func (c *csiSnapshotOperator) syncDeployment(instance *operatorv1.CSISnapshotController) (*appsv1.Deployment, error) {
 	deploy := c.getExpectedDeployment(instance)
 
+	// Update the deployment when something updated CSISnapshotController.Spec.LogLevel.
+	// The easiest check is for Generation update (i.e. redeploy on any CSISnapshotController.Spec change).
+	// This may update the Deployment more than it is strictly necessary, but the overhead is not that big.
+	forceRollout := false
+	if instance.Generation != instance.Status.ObservedGeneration {
+		forceRollout = true
+	}
+
 	deploy, _, err := resourceapply.ApplyDeployment(
 		c.kubeClient.AppsV1(),
 		c.eventRecorder,
 		deploy,
 		resourcemerge.ExpectedDeploymentGeneration(deploy, instance.Status.Generations),
-		false)
+		forceRollout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The operator needs to update Deployment it operates when a change is required by user (or something else).

Source of these changes are:
* `CSISnapshotController.Spec.LogLevel` - handled in this PR.
* Env. variable `OPERAND_IMAGE` - it can't change during the operator lifetime and I checked the operator correctly applies new `OPERAND_IMAGE` to Deployment on operator restart.

Note that this PR applies changes to the Deployment on all changes in `CSISnapshotController.Spec`, which is not optimal, but it should be sufficient enough. At least authentication operator does the same.