### PR TITLE
Wait for informer sync before starting the controller

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -119,6 +119,12 @@ func (c *csiSnapshotOperator) Run(workers int, stopCh <-chan struct{}) {
 
 	c.stopCh = stopCh
 
+	klog.Infof("Starting csi-snapshot-controller")
+
+	if !cache.WaitForNamedCacheSync("csi-snapshot-controller", stopCh, c.crdListerSyncer, c.deployListerSynced) {
+		return
+	}
+
 	for i := 0; i < workers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}


### PR DESCRIPTION
This is a small PR that ensures that we wait for informers to be synced before starting the operator-controller
