### PR TITLE
Update Deployment on image version change

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -219,6 +219,10 @@ func (c *csiSnapshotOperator) setVersion(operandName, version string) {
 	}
 }
 
+func (c *csiSnapshotOperator) versionChanged(operandName, version string) bool {
+	return c.versionGetter.GetVersions()[operandName] != version
+}
+
 func (c *csiSnapshotOperator) enqueue(obj interface{}) {
 	// we're filtering out config maps that are "leader" based and we don't have logic around them
 	// resyncing on these causes the operator to sync every 14s for no good reason

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -80,6 +80,16 @@ func (c *csiSnapshotOperator) syncDeployment(instance *operatorv1.CSISnapshotCon
 		forceRollout = true
 	}
 
+	if c.versionChanged("operator", operatorVersion) {
+		// Operator version changed. The new one _may_ have updated Deployment -> we should deploy it.
+		forceRollout = true
+	}
+
+	if c.versionChanged("csi-snapshot-controller", operandVersion) {
+		// Operand version changed. Update the deployment with a new image.
+		forceRollout = true
+	}
+
 	deploy, _, err := resourceapply.ApplyDeployment(
 		c.kubeClient.AppsV1(),
 		c.eventRecorder,


### PR DESCRIPTION
Force controller deployment update when:
- the operator version changes, it could have a different controller Deployment template. So force-deploy it.
- the controller version changes, so the Deployment gets new image.