### PR TITLE
Fix must-gather namespace names

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -32,11 +32,10 @@ var log = logf.Log.WithName("csi_snapshot_controller_operator")
 var deploymentVersionHashKey = operatorv1.GroupName + "/rvs-hash"
 
 const (
-	targetName                = "csi-snapshot-controller"
-	targetNamespace           = "openshift-csi-snapshot-controller"
-	targetNameSpaceController = "openshift-csi-controller"
-	targetDeploymentName      = "csi-snapshot-controller"
-	globalConfigName          = "cluster"
+	targetName        = "csi-snapshot-controller"
+	targetNamespace   = "openshift-csi-snapshot-controller"
+	operatorNamespace = "openshift-csi-snapshot-controller-operator"
+	globalConfigName  = "cluster"
 
 	operatorVersionEnvName = "OPERATOR_IMAGE_VERSION"
 	operandVersionEnvName  = "OPERAND_IMAGE_VERSION"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -11,13 +11,12 @@ import (
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
 	csisnapshotconfigclient "github.com/openshift/client-go/operator/clientset/versioned"
 	informer "github.com/openshift/client-go/operator/informers/externalversions"
-	common "github.com/openshift/cluster-csi-snapshot-controller-operator/pkg/common"
+	"github.com/openshift/cluster-csi-snapshot-controller-operator/pkg/common"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/status"
 
-	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/klog"
@@ -71,9 +70,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		targetName,
 		[]configv1.ObjectReference{
 			{Resource: "namespaces", Name: targetNamespace},
-			{Resource: "namespaces", Name: targetNameSpaceController},
+			{Resource: "namespaces", Name: operatorNamespace},
 			{Group: operatorv1.GroupName, Resource: "csisnapshotcontrollers", Name: globalConfigName},
-			{Group: appsv1.GroupName, Resource: "deployments", Namespace: targetNameSpaceController, Name: targetDeploymentName},
 		},
 		configClient.ConfigV1(),
 		configInformers.Config().V1().ClusterOperators(),


### PR DESCRIPTION
Tested on a cluster, there are logs both from the csi-snapshot-controller and csi-snapshot-controller-operator included in must-gather now.