### PR TITLE
Bug 1798448: Use Origin images from quay.io/openshift

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -22,8 +22,7 @@ spec:
       serviceAccountName: csi-snapshot-controller-operator
       containers:
       - name: operator
-        # TODO: fix to origin image
-        image: quay.io/jsafrane/csi-snapshot-operator:latest
+        image: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator:latest
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -32,8 +31,7 @@ spec:
         args: [ "start", "-v", "5" , "--config=/var/run/configmaps/config/operator-config.yaml"]
         env:
         - name: OPERAND_IMAGE
-          # TODO: fix to origin image
-          value: quay.io/k8scsi/snapshot-controller:v2.0.0
+          value: quay.io/openshift/origin-csi-snapshot-controller
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERAND_IMAGE_VERSION

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,8 +5,8 @@ spec:
   - name: cluster-csi-snapshot-controller-operator
     from:
       kind: DockerImage
-      name: quay.io/jsafrane/csi-snapshot-operator:latest
+      name: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator
   - name: csi-snapshot-controller
     from:
       kind: DockerImage
-      name: quay.io/k8scsi/snapshot-controller:v2.0.0
+      name: quay.io/openshift/origin-csi-snapshot-controller


### PR DESCRIPTION
Use the latest OKD images when installing the operator manually via `oc create -f manifests/`.