### PR TITLE
Bug 1829320: UPSTREAM: 787: Fix ClusterOperator event when version changes

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers/status.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers/status.go
@@ -92,6 +92,10 @@ func GetStatusDiff(oldStatus configv1.ClusterOperatorStatus, newStatus configv1.
 		messages = append(messages, fmt.Sprintf("status.extension changed from %q to %q", oldStatus.Extension, newStatus.Extension))
 	}
 
+	if !equality.Semantic.DeepEqual(oldStatus.Versions, newStatus.Versions) {
+		messages = append(messages, fmt.Sprintf("status.versions changed from %q to %q", oldStatus.Versions, newStatus.Versions))
+	}
+
 	if len(messages) == 0 {
 		// ignore errors
 		originalJSON := &bytes.Buffer{}


### PR DESCRIPTION
This is cherry-pick of https://github.com/openshift/library-go/pull/787.
@openshift/storage 