### PR TITLE
Bug 1841035: Add permissions to snapshot CRs to various cluster roles

### DIFF
--- a/manifests/05_user_rbac.yaml
+++ b/manifests/05_user_rbac.yaml
@@ -1,0 +1,72 @@
+# Add permissions to admin and regular users to manipulate with snapshot CRs.
+
+# Allow namespace level admin & editor full access to namespaced VolumeSnapshots.
+# I.e. users that can edit objects in a namespace can create/delete snapshots.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:openshift:aggregate-snapshots-to-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+
+---
+
+# Allow namespace level viewer read-only access.
+# I.e. users with read-only access to a namespace can read snapshots.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:openshift:aggregate-snapshots-to-view
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+# Allow basic-user read-only access to VolumeSnapshotClass.
+# I.e. regular user can list snapshot classes, as they can list storage classes.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:openshift:aggregate-snapshots-to-basic-user
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    authorization.openshift.io/aggregate-to-basic-user: "true"
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+# Allow storage-admin read-write access to non-namespaced objects
+# + read-only access to namespaced objects (across all namespaces).
+# This follows storage-admin access to PVs/PVCs and StorageClasses.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:openshift:aggregate-snapshots-to-storage-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    storage.openshift.io/aggregate-to-storage-admin: "true"
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses", "volumesnapshotcontents"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
- storage-admin owns the cluster-scoped objects and can read namespaced
  CRs.
- Namespace admin / editor owns namespaced objects.
- Namespace viewer can read namespaced objects.
- Basic uses can read VolumeSnapshotClasses.

/hold
It needs https://github.com/openshift/openshift-apiserver/pull/113 merged first.