### PR TITLE
Bug 1876858: manifests: rename operator container to be more descriptive

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: csi-snapshot-controller-operator
       containers:
-      - name: operator
+      - name: csi-snapshot-controller-operator
         image: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator:latest
         imagePullPolicy: IfNotPresent
         resources:


### PR DESCRIPTION

Rename the operator container to allow for more reasonable debugging.