### PR TITLE
Bug 1879365: Remove namespace creation

### DIFF
--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-cluster-storage-operator
-  annotations:
-    openshift.io/node-selector: ""
-  labels:
-    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
The namespace manifest is in cluster-storage-operator manifests and it's created before CVO evaluates csnapshot operator manifests (i.e. it has lower runlevel).

cc @openshift/storage 

/hold
for https://github.com/openshift/cluster-storage-operator/pull/89 to be merged first