### PR TITLE
Bug 1839239: Update version only after having rolled out the new operand

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -159,8 +159,17 @@ func (c *csiSnapshotOperator) syncStatus(instance *operatorv1.CSISnapshotControl
 		instance.Status.ReadyReplicas = deployment.Status.UpdatedReplicas
 	}
 
-	c.setVersion("operator", c.operatorVersion)
-	c.setVersion("csi-snapshot-controller", c.operandVersion)
+	// Only set versions if we reached the desired state
+	isAvailable := v1helpers.IsOperatorConditionTrue(
+		instance.Status.Conditions,
+		operatorv1.OperatorStatusTypeAvailable)
+	isProgressing := v1helpers.IsOperatorConditionTrue(
+		instance.Status.Conditions,
+		operatorv1.OperatorStatusTypeProgressing)
+	if isAvailable && !isProgressing {
+		c.setVersion("operator", c.operatorVersion)
+		c.setVersion("csi-snapshot-controller", c.operandVersion)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Versions should be set after the operand has rolled out.