### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/02_operator_cr.yaml
+++ b/manifests/02_operator_cr.yaml
@@ -6,5 +6,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/03_service.yaml
+++ b/manifests/03_service.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: csi-snapshot-controller-operator
   name: csi-snapshot-controller-operator-metrics

--- a/manifests/04_serviceaccount.yaml
+++ b/manifests/04_serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-
+    include.release.openshift.io/single-node-production-edge: "true"
 ---
 
 apiVersion: v1
@@ -19,3 +19,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/05_operand_rbac.yaml
+++ b/manifests/05_operand_rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -39,6 +40,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
   - kind: ServiceAccount
     name: csi-snapshot-controller
@@ -57,6 +59,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -71,6 +74,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
   - kind: ServiceAccount
     name: csi-snapshot-controller

--- a/manifests/05_operator_rbac.yaml
+++ b/manifests/05_operator_rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
   - kind: ServiceAccount
     name: csi-snapshot-controller-operator

--- a/manifests/05_user_rbac.yaml
+++ b/manifests/05_user_rbac.yaml
@@ -14,6 +14,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshots"]
@@ -34,6 +35,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshots"]
@@ -54,6 +56,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshotclasses"]
@@ -75,6 +78,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshotclasses", "volumesnapshotcontents"]

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     config.openshift.io/inject-proxy: csi-snapshot-controller-operator
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08_webhook_service.yaml
+++ b/manifests/08_webhook_service.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   ports:
   - name: webhook

--- a/manifests/09_webhook_config.yaml
+++ b/manifests/09_webhook_config.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 webhooks:
   - name: volumesnapshotclasses.snapshot.storage.k8s.io
     clientConfig:

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 status:
   versions:
   - name: operator


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.