### PR TITLE
Bug 1905320: Add memory limit for webhook container.

### DIFF
--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -32,6 +32,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            memory: 20Mi
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       nodeSelector:

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -27,7 +27,7 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           requests:
-            memory: 50Mi
+            memory: 65Mi
             cpu: 10m
         args: [ "start", "-v", "5" , "--config=/var/run/configmaps/config/operator-config.yaml"]
         env:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -705,6 +705,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            memory: 20Mi
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       nodeSelector:


### PR DESCRIPTION
And adjust CSI snapshot operator memory request. Measured in https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4.7.0-0.nightly/release/4.7.0-0.nightly-2020-12-04-013308:

* The operator took 63MiB for most of the CI run: `container_memory_max_usage_bytes{container="csi-snapshot-controller-operator",..., pod="csi-snapshot-controller-operator-8555964b44-lzsxd"} 66138112`
* The webhook took 17 MiB for most of the CI run: `container_memory_max_usage_bytes{container="webhook", ..., pod="csi-snapshot-webhook-f7bb59b75-8wqcq"} 18132992`

For the record, snapshot-controller memory requirement is OK.