### PR TITLE
Bug 1908349: Don't validate v1 objects

### DIFF
--- a/manifests/09_webhook_config.yaml
+++ b/manifests/09_webhook_config.yaml
@@ -18,7 +18,7 @@ webhooks:
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["snapshot.storage.k8s.io"]
-        apiVersions: ["v1", "v1beta1"]
+        apiVersions: ["v1beta1"]
         resources: ["volumesnapshots", "volumesnapshotcontents"]
     sideEffects: None
     failurePolicy: Ignore


### PR DESCRIPTION
Upstream webhook, as it is now, can validate only v1beta1 objects and fails any v1 object validation.

cc @openshift/storage 
All Feature:VolumeSnapshotDataSource tests are failing, see the BZ for details.