### PR TITLE
Bug 1907287: Use webhook for v1 snapshot API

### DIFF
--- a/assets/webhook_config.yaml
+++ b/assets/webhook_config.yaml
@@ -17,7 +17,7 @@ webhooks:
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["snapshot.storage.k8s.io"]
-        apiVersions: ["v1beta1"]
+        apiVersions: ["v1beta1", "v1"]
         resources: ["volumesnapshots", "volumesnapshotcontents"]
     admissionReviewVersions:
       - v1

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -819,7 +819,7 @@ webhooks:
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["snapshot.storage.k8s.io"]
-        apiVersions: ["v1beta1"]
+        apiVersions: ["v1beta1", "v1"]
         resources: ["volumesnapshots", "volumesnapshotcontents"]
     admissionReviewVersions:
       - v1


### PR DESCRIPTION
v1 API validation was disabled for CI, let's enable it now