### PR TITLE
Bug 1926444: Fix installation on ROKS

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: csi-snapshot-controller-operator
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/08_webhook_service.yaml
+++ b/manifests/08_webhook_service.yaml
@@ -7,6 +7,7 @@ metadata:
     app: csi-snapshot-webhook
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: csi-snapshot-controller
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 status:


### PR DESCRIPTION
The operator should be installed on ROKS. Fix annotations in files that missed it.

@openshift/storage 