### PR TITLE
Bug 1951066: Remove exclude annotation from manifests to include in ROKS

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: csi-snapshot-controller-operator
   annotations:
     config.openshift.io/inject-proxy: csi-snapshot-controller-operator
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -3,7 +3,6 @@ kind: ClusterOperator
 metadata:
   name: csi-snapshot-controller
   annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
Follow up to https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/79
The annotations to exclude manifests should also be removed.