### PR TITLE
Add management workload annotations

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -11,6 +11,8 @@ spec:
       app: csi-snapshot-controller
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller
     spec:

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -11,6 +11,8 @@ spec:
       app: csi-snapshot-webhook
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-webhook
     spec:

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: csi-snapshot-controller-operator
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
     spec:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -72,6 +72,8 @@ spec:
       app: csi-snapshot-controller
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller
     spec:
@@ -857,6 +859,8 @@ spec:
       app: csi-snapshot-webhook
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-webhook
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>