### PR TITLE
Bug 1961538: manifests/05_operator_rbac: Drop the unused namespace property

### DIFF
--- a/manifests/05_operator_rbac.yaml
+++ b/manifests/05_operator_rbac.yaml
@@ -2,7 +2,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-snapshot-controller-operator-role
-  namespace: openshift-cluster-storage-operator
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
`ClusterRoleBinding` is [cluster][1]-[scoped][2], and the presence of this property in the manifest [causes the CVO to hot-loop][3].

[1]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrolebinding-example
[2]: https://github.com/kubernetes/api/blob/9b64426eca51a74faa7cc9bd732a533d339c69c2/rbac/v1/types.go#L195-L200
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1961538