### PR TITLE
Bug 1965263: VolumeSnapshotContents listing should print also namespace of the VolumeSnapshot ref.

### DIFF
--- a/assets/volumesnapshotcontents.yaml
+++ b/assets/volumesnapshotcontents.yaml
@@ -42,6 +42,10 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -176,6 +180,10 @@ spec:
     - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
+      type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -336,6 +336,10 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -470,6 +474,10 @@ spec:
     - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
+      type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
Getting the VolumeSnapshotContents from CLI will print also the VolumeSnapshot it references. This is however not sufficient to identify the correct VolumeSnapshot object since it's namespaced. This patch adds alos the namespace column to the printed information.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1965263