### PR TITLE
Add ibm-cloud-managed profile patch for operator deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 csi-snapshot-controller-operator
+_output/

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/deps-gomod.mk \
 	targets/openshift/images.mk \
 	targets/openshift/bindata.mk \
+	targets/openshift/operator/profile-manifests.mk \
 )
 
 # Run core verification and all self contained tests.
@@ -26,6 +27,14 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
 $(call build-image,ocp-cluster-csi-snapshot-operator,$(IMAGE_REGISTRY)/ocp/4.4:cluster-csi-snapshot-operator,./Dockerfile.rhel7,.)
+
+# This will include additional actions on the update and verify targets to ensure that profile patches are applied
+# to manifest files
+# $0 - macro name
+# $1 - target name
+# $2 - profile patches directory
+# $3 - manifests directory
+$(call add-profile-manifests,manifests,./profile-patches,./manifests)
 
 clean:
 	$(RM) csi-snapshot-controller-operator

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -1,0 +1,76 @@
+# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+  labels:
+    app: csi-snapshot-controller-operator
+  name: csi-snapshot-controller-operator
+  namespace: openshift-cluster-storage-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-snapshot-controller-operator
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: csi-snapshot-controller-operator
+      name: csi-snapshot-controller-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v
+        - "5"
+        - --config=/var/run/configmaps/config/operator-config.yaml
+        env:
+        - name: OPERAND_IMAGE
+          value: quay.io/openshift/origin-csi-snapshot-controller
+        - name: WEBHOOK_IMAGE
+          value: registry.svc.ci.openshift.org/ocp/4.7:csi-snapshot-validation-webhook
+        - name: OPERATOR_IMAGE_VERSION
+          value: 0.0.1-snapshot
+        - name: OPERAND_IMAGE_VERSION
+          value: 0.0.1-snapshot
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator:latest
+        imagePullPolicy: IfNotPresent
+        name: csi-snapshot-controller-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 65Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+      priorityClassName: system-cluster-critical
+      securityContext:
+        fsGroup: 10400
+        runAsGroup: 10400
+        runAsUser: 10400
+      serviceAccountName: csi-snapshot-controller-operator
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 440
+          name: csi-snapshot-controller-operator-config
+        name: config

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: csi-snapshot-controller-operator
   annotations:
     config.openshift.io/inject-proxy: csi-snapshot-controller-operator
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/annotations
+  value:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+- op: remove
+  path: /spec/template/spec/nodeSelector


### PR DESCRIPTION
Adds patch to generate an ibm-cloud-managed specific deployment manifest for this operator.
This is needed to deploy the operator in a topology where there are no master nodes.