### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -47,6 +47,11 @@ spec:
           requests:
             cpu: 10m
             memory: 65Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/config
@@ -55,7 +60,10 @@ spec:
       securityContext:
         fsGroup: 10400
         runAsGroup: 10400
+        runAsNonRoot: true
         runAsUser: 10400
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: csi-snapshot-controller-operator
       tolerations:
       - effect: NoExecute

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -30,6 +30,11 @@ spec:
           requests:
             memory: 65Mi
             cpu: 10m
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         args: [ "start", "-v", "5" , "--config=/var/run/configmaps/config/operator-config.yaml"]
         env:
         - name: OPERAND_IMAGE
@@ -72,4 +77,7 @@ spec:
       securityContext:
         fsGroup: 10400
         runAsGroup: 10400
+        runAsNonRoot: true
         runAsUser: 10400
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-cluster-storage-operator/deployments/csi-snapshot-controller-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"csi-snapshot-controller-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"csi-snapshot-controller-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"csi-snapshot-controller-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"csi-snapshot-controller-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 