### PR TITLE
AUTH-133: assets: comply to restricted pod security level

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -20,9 +20,18 @@ spec:
       labels:
         app: csi-snapshot-controller
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: csi-snapshot-controller
       containers:
         - name: snapshot-controller
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           image: quay.io/k8scsi/snapshot-controller:v2.2.0-rc1
           args:
             - "--v=5"

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -39,6 +39,11 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -50,6 +55,10 @@ spec:
                 topologyKey: kubernetes.io/hostname
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       nodeSelector:
         node-role.kubernetes.io/master: ""
       volumes:


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
$ oc -n openshift-cluster-storage-operator logs csi-snapshot-controller-operator-66578b8669-kdbnl | grep "would violate PodSecurity"
W0512 01:45:31.019201 1 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "webhook" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "webhook" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "webhook" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "webhook" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0512 01:45:34.319263 1 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "snapshot-controller" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "snapshot-controller" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "snapshot-controller" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "snapshot-controller" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0512 01:45:34.418274 1 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "snapshot-controller" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "snapshot-controller" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "snapshot-controller" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "snapshot-controller" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

/cc @stlaz 