### PR TITLE
WIP: HyperShift proof of concept

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -41,12 +41,16 @@ spec:
             - "--leader-election-lease-duration=137s"
             - "--leader-election-renew-deadline=107s"
             - "--leader-election-retry-period=26s"
+            # Force the namespace name for HyperShift
+            - "--leader-election-namespace=openshift-cluster-storage-operator"
+            # guest --kubeconfig= will be injected by the operator when running on HyperShift
           imagePullPolicy: IfNotPresent
           resources:
             requests:
               # TODO: measure on a real cluster
               cpu: 10m
               memory: 50Mi
+          # volumeMount with guest Kubeconfig will be added by the operator
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -71,3 +75,4 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: "NoSchedule"
+      # volume with guest Kubeconfig will be added by the operator

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -34,6 +34,7 @@ spec:
           - name: certs
             mountPath: /etc/snapshot-validation-webhook/certs
             readOnly: true
+            optional: true
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/cmd/csi-snapshot-controller-operator/main.go
+++ b/cmd/csi-snapshot-controller-operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,10 @@ func main() {
 	os.Exit(code)
 }
 
+var (
+	guestKubeconfig *string
+)
+
 func NewCSISnapshotControllerOperatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "csi-snapshot-controller-operator",
@@ -28,11 +33,16 @@ func NewCSISnapshotControllerOperatorCommand() *cobra.Command {
 		},
 	}
 
-	cmd2 := controllercmd.NewControllerCommandConfig("csi-snapshot-controller-operator", version.Get(), operator.RunOperator).NewCommand()
+	cmd2 := controllercmd.NewControllerCommandConfig("csi-snapshot-controller-operator", version.Get(), runOperatorWithGuestKubeconfig).NewCommand()
 	cmd2.Use = "start"
 	cmd2.Short = "Start the CSI Snapshot Controller Operator"
+	guestKubeconfig = cmd2.Flags().String("guest-kubeconfig", "", "Path to the guest kubeconfig file. This flag enables hypershift integration.")
 
 	cmd.AddCommand(cmd2)
 
 	return cmd
+}
+
+func runOperatorWithGuestKubeconfig(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
+	return operator.RunOperator(ctx, controllerConfig, *guestKubeconfig)
 }

--- a/pkg/common/builder.go
+++ b/pkg/common/builder.go
@@ -1,13 +1,9 @@
 package common
 
 import (
-	"os"
-
 	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 )
 
 // Builder can create a variety of kubernetes client interface
@@ -27,25 +23,7 @@ func (cb *Builder) KubeClientOrDie(name string) kubernetes.Interface {
 }
 
 // NewBuilder returns a *ClientBuilder with the given kubeconfig.
-func NewBuilder(kubeconfig string) (*Builder, error) {
-	var config *rest.Config
-	var err error
-
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-
-	if kubeconfig != "" {
-		klog.Infof("Loading kube client config from path %q", kubeconfig)
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-	} else {
-		klog.Infof("Using in-cluster kube client config")
-		config, err = rest.InClusterConfig()
-	}
-	if err != nil {
-		return nil, err
-	}
-
+func NewBuilder(config *rest.Config) (*Builder, error) {
 	return &Builder{
 		config: config,
 	}, nil

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -168,6 +168,7 @@ func newOperator(test operatorTest) *testContext {
 		testVersion,
 		testVersion,
 		test.image,
+		defaultTargetNamespace,
 	)
 
 	return &testContext{
@@ -240,7 +241,7 @@ func withGenerations(depolymentGeneration int64) csiSnapshotControllerModifier {
 				Group:          appsv1.GroupName,
 				LastGeneration: depolymentGeneration,
 				Name:           targetName,
-				Namespace:      targetNamespace,
+				Namespace:      defaultTargetNamespace,
 				Resource:       "deployments",
 			},
 		}
@@ -800,7 +801,7 @@ func TestSync(t *testing.T) {
 
 			// Check expectedObjects.deployment
 			if test.expectedObjects.deployment != nil {
-				actualDeployment, err := ctx.coreClient.AppsV1().Deployments(targetNamespace).Get(context.TODO(), targetName, metav1.GetOptions{})
+				actualDeployment, err := ctx.coreClient.AppsV1().Deployments(defaultTargetNamespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 				if err != nil {
 					t.Errorf("Failed to get Deployment %s: %v", targetName, err)
 				}

--- a/pkg/operator/webhookdeployment/webhook_test.go
+++ b/pkg/operator/webhookdeployment/webhook_test.go
@@ -124,6 +124,7 @@ func newOperator(test operatorTest) *testContext {
 		coreClient,
 		recorder,
 		test.image,
+		"openshift-cluster-storage-operator",
 	)
 
 	return &testContext{


### PR DESCRIPTION
Quick and dirty update of the operator for HyperShift. No time for small commits :-).

Required changes:
* Add `--guest-kubeconfig` to the operator for the kubeconfig of the guest cluster.
* Rework `pkg/common/builder.go` a bit to simplify initialization, but it deserves complete overhaul (or removal?).
* Try to use variables `managementKubeClient` and `guestKubeClient` for kubeclients to make them more obvious.
    * Still use these two kubeClients even in standalone OCP (outside of HyperShift). They're the same there.
* Create informers using the right kubeClient.
* Pass `operandNamespace` from cmdline to all controllers than need to create stuff in the management cluster.
    *  Rework the controllers to replace the namespace in all namespaced objects that run in the management cluster.
* Add `--leader-election-namespace` to the operand (snapshot-controller) cmdline, otherwise it's read from env vars, which lead to the management cluster and not the guest cluster.
* Only in HyperShift:
    * Add `--kubeconfig=`  + add a Secret volume with the admin kubeconfig to both operands.


Usage:
```shell
# Guest cluster namespace in the management cluster
$ export NS=clusters-hypershift-ci-1211
# Create service account for the operand. This may be created by control-plane-operator
# in the future or as a static resource.
$ kubectl -n $NS create serviceaccount "csi-snapshot-controller"
$ ./csi-snapshot-controller-operator start --kubeconfig="management_cluster_kubeconfig" \
    --guest-kubeconfig=guest_cluster_kubeconfig  -v 5 --namespace=$NS
```

TODO:
* Webhook does not work (it does not have secret with TLS key)
* Update namespace of PodDisruptionBudget instances. They should be created in the management cluster namespace for the guest cluster, but they're created by StaticResourceController.
* Rework the unit tests to check which kubeclient was used for which object.

