### PR TITLE
OCPBUGS-990: Add RBAC to read extension-apiserver-authentication in kube-system

### DIFF
--- a/manifests/05_operator_apiserver_authentication_reader.yaml
+++ b/manifests/05_operator_apiserver_authentication_reader.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-snapshot-controller-operator-authentication-reader
+  namespace: kube-system
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: csi-snapshot-controller-operator
+  namespace: openshift-cluster-storage-operator

--- a/manifests/05_operator_role.yaml
+++ b/manifests/05_operator_role.yaml
@@ -18,6 +18,7 @@ rules:
   - apps
   resources:
   - deployments
+  - replicasets
   verbs:
   - "*"
 - apiGroups:


### PR DESCRIPTION
The operator fails with:

> Unable to get configmap/extension-apiserver-authentication in kube-system. Usually fixed by
> 'kubectl create rolebinding -n kube-system ROLEBINDING_NAME --role=extension-apiserver-authentication-reader --serviceaccount=YOUR_NS:YOUR_SA'

And:

> builder.go:230] unable to get owner reference (falling back to namespace): replicasets.apps "csi-snapshot-controller-operator-597c947cf" is forbidden: User "system:serviceaccount:openshift-cluster-storage-operator:csi-snapshot-controller-operator" cannot get resource "replicasets" in API group "apps" in the namespace "openshift-cluster-storage-operator"

This was caused by a recent RBAC refactoring. Add the missing RoleBinding + update Role.

@openshift/storage 