### PR TITLE
OCPBUGS-3973: Don't remove PDB on SNO clusters

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -159,19 +159,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			return !isSNO
 		},
 		func() bool {
-			if isHyperShift {
-				return false
-			}
-			isSNO, precheckSucceeded, err := staticcontrollercommon.NewIsSingleNodePlatformFn(guestConfigInformers.Config().V1().Infrastructures())()
-			if err != nil {
-				klog.Errorf("NewIsSingleNodePlatformFn failed: %v", err)
-				return false
-			}
-			if !precheckSucceeded {
-				klog.V(4).Infof("NewIsSingleNodePlatformFn precheck did not succeed, skipping")
-				return false
-			}
-			return isSNO
+			return false
 		},
 	).AddKubeInformers(controlPlaneInformersForNamespaces)
 


### PR DESCRIPTION
On SingleNodeClusters, don't remove PodDisruptionBudget, because the operator does not have permissions for it. And the PDB should not exist there anyway.

cc @openshift/storage 