### PR TITLE
Add apiGroup to all role/clusterrole references

### DIFF
--- a/manifests/06_operator_clusterrolebinding.yaml
+++ b/manifests/06_operator_clusterrolebinding.yaml
@@ -15,5 +15,6 @@ subjects:
     name: csi-snapshot-controller-operator
     namespace: openshift-cluster-storage-operator
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: csi-snapshot-controller-operator-clusterrole

--- a/manifests/06_operator_operand_clusterrolebinding.yaml
+++ b/manifests/06_operator_operand_clusterrolebinding.yaml
@@ -15,5 +15,6 @@ subjects:
     name: csi-snapshot-controller-operator
     namespace: openshift-cluster-storage-operator
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: openshift-csi-snapshot-controller-runner

--- a/manifests/06_operator_rolebinding-hypershift.yaml
+++ b/manifests/06_operator_rolebinding-hypershift.yaml
@@ -7,6 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: csi-snapshot-controller-operator-role
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: csi-snapshot-controller-operator-role
 subjects:

--- a/manifests/06_operator_rolebinding.yaml
+++ b/manifests/06_operator_rolebinding.yaml
@@ -14,5 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: csi-snapshot-controller-operator
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: csi-snapshot-controller-operator-role


### PR DESCRIPTION
HyperShift's control-plane-operator requires `apiGroup` to be present in `6_operator_rolebinding-hypershift.yaml`, because we copy this file to hypershift repo. To make it consistent, I added the `apiGroup` to all `ruleRef` fields in all `manifests/`.

This should help with `WARNING: Object got updated more than one time without a no-op update` in HyperShift CI: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hypershift/1698/pull-ci-openshift-hypershift-main-e2e-aws/1597168718226395136