### PR TITLE
OCPBUGS-4490: hypershift: use correct kubeconfig secret for csi-snapshot-controller

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -192,7 +192,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		deploymentHooks = []dc.DeploymentHookFunc{
 			hyperShiftReplaceNamespaceHook(controlPlaneNamespace),
 			hyperShiftRemoveNodeSelector(),
-			hyperShiftAddKubeConfigVolume("admin-kubeconfig"), // TODO: use dedicated secret for Snapshots
+			hyperShiftAddKubeConfigVolume("service-network-admin-kubeconfig"), // TODO: use dedicated secret for Snapshots
 		}
 	} else {
 		// Standalone OCP


### PR DESCRIPTION
`admin-kubeconfig` is only for external end users and does not work when the cluster is `endpointAccess: Private`.  Use the `service-network-admin-kubeconfig` instead.

https://issues.redhat.com/browse/OCPBUGS-4490