### PR TITLE
OCPBUGS-8374: Add UID to CSO Pod to be able to run with custom SCCs

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -53,6 +53,7 @@ spec:
           name: guest-kubeconfig
       securityContext:
         runAsNonRoot: true
+        runAsUser: 11412
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: csi-snapshot-controller-operator

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -54,6 +54,7 @@ spec:
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
+        runAsUser: 11412
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: csi-snapshot-controller-operator

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -69,5 +69,9 @@ spec:
         effect: "NoSchedule"
       securityContext:
         runAsNonRoot: true
+        # Force a specific UID, just in case this Pod matches a custom SCC with "runAsUser: type: runAsNonRoot".
+        # The UID value is UID of cluster-storage-operator + 1
+        # In 4.13, we have proper RBACs for the operator and explicit UID is not needed there.
+        runAsUser: 11412
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
When there is a custom SCC with "runAsUser: type: runAsNonRoot", snapshot-operator pod can match it. Then the Pod must have a non-root UID assigned to be able to run,

This moves the snapshot-operator Pods from "restricted-v2" SCC to "nonroot-v2" SCC in the default OCP installation.

This is a workaround for the operator using cluster-admin role, which can allow the operator to use any SCC. In 4.13, we [already have proper RBAC rules for the operator](https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/124), so this UID is not needed there.

cc @openshift/storage 