### PR TITLE
OCPBUGS-8374: [4.12] remove cluster-admin role.

### DIFF
--- a/manifests/05_operator_remove_cluster_admin.yaml
+++ b/manifests/05_operator_remove_cluster_admin.yaml
@@ -1,0 +1,21 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-controller-operator-role
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    # Remove this ClusterRoleBinding during upgrade,
+    # the operator does not need cluster-admin.
+    release.openshift.io/delete: "true"
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshot-controller-operator
+    namespace: openshift-cluster-storage-operator
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin


### PR DESCRIPTION
The snapshot operator has proper RBACs in 4.12 and should not use cluster-admin role. Therefore delete its ClusterRoleBinding during upgrade.

@openshift/storage 