### PR TITLE
OCPBUGS-3680: Set readOnlyRootFilesystem to false

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -52,6 +52,7 @@ spec:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
       securityContext:
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -53,6 +53,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -69,5 +69,6 @@ spec:
         effect: "NoSchedule"
       securityContext:
         runAsNonRoot: true
+        readOnlyRootFilesystem: false
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
Explicitly ask for readOnlyFilesystem set to false. Fixes https://issues.redhat.com/browse/OCPBUGS-3680