### PR TITLE
HOSTEDCP-1063: allow webhooks in hosted clusters to reach csi-snapshot-webhook service

### DIFF
--- a/assets/webhook_service.yaml
+++ b/assets/webhook_service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ${CONTROLPLANE_NAMESPACE}
   labels:
     app: csi-snapshot-webhook
+    hypershift.openshift.io/allow-guest-webhooks: "true"
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret
     capability.openshift.io/name: CSISnapshot


### PR DESCRIPTION
We are preventing/deleting any webhook that runs in a hosted cluster and targets a service running in the management cluster here: https://github.com/openshift/hypershift/pull/2775

This PR adds a label to the `csi-snapshot-webhook` service to ensure `snapshot.storage.k8s.io` webhook doesn't get deleted.

Although the original PR was merged, there was a bug which made it not detect the `snapshot.storage.k8s.io` webhook, otherwise it would have been deleted. This needs to be merged before the fix is merged in the hypershit repo https://github.com/openshift/hypershift/pull/2898

Fixes #[HOSTEDCP-1063](https://issues.redhat.com/browse/HOSTEDCP-1063)