### PR TITLE
STOR-1443: Restart webhook Pods if `csi-snapshot-webhook-secret` changed

### DIFF
--- a/manifests/05_operator_role-hypershift.yaml
+++ b/manifests/05_operator_role-hypershift.yaml
@@ -68,6 +68,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - hypershift.openshift.io
   resources:
   - hostedcontrolplanes

--- a/manifests/05_operator_role.yaml
+++ b/manifests/05_operator_role.yaml
@@ -72,4 +72,11 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
 


### PR DESCRIPTION
Adding `WithSecretHashAnnotationHook()` for `csi-snapshot-webhook-secret` ensures that new annotation is published in `csi-snapshot-webhook` Deployment. This, in turn, leads to webhook pods restart.