### PR TITLE
OCPBUGS-18801: Move readonlyRootFilesystem to the right place - 4.14

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -47,12 +47,12 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
       securityContext:
-        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -50,10 +50,10 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:
-        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -32,6 +32,7 @@ spec:
             cpu: 10m
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
           capabilities:
             drop:
             - ALL
@@ -69,6 +70,5 @@ spec:
         effect: "NoSchedule"
       securityContext:
         runAsNonRoot: true
-        readOnlyRootFilesystem: false
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/OCPBUGS-18801