### PR TITLE
OCPBUGS-19511: Move readonlyRootFilesystem to the right place - 4.12

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -47,6 +47,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -50,6 +50,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -32,6 +32,7 @@ spec:
             cpu: 10m
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-19511