### PR TITLE
remove unused loglevel

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -20,7 +20,6 @@ spec:
       containers:
       - args:
         - start
-        - -v=2
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -24,7 +24,6 @@ spec:
       containers:
       - args:
         - start
-        - -v=2
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/origin-csi-snapshot-controller

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -38,7 +38,6 @@ spec:
             - ALL
         args:
         - start
-        - -v=2
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/origin-csi-snapshot-controller


### PR DESCRIPTION
As the operator loglevel is controlled by the cr operatorLogLevel, and the --v in the deployment has no effect anymore, we should remove the redundant flag

related to https://github.com/openshift/cluster-kube-scheduler-operator/pull/487