### PR TITLE
HOSTEDCP-1308: Revert "HOSTEDCP-1308: add KAS access label to csi-snapshot-controller and csi-snapshot-webhook"

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -22,7 +22,6 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller
-        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -19,7 +19,6 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-webhook
-        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       containers:
       - name: webhook


### PR DESCRIPTION
Revert https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/182

webhook and controller pods don't need management KAS access.