### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -53,6 +53,7 @@ spec:
               # TODO: measure on a real cluster
               cpu: 10m
               memory: 50Mi
+          terminationMessagePolicy: FallbackToLogsOnError
           # volumeMount with guest Kubeconfig will be added by the operator
       affinity:
         podAntiAffinity:

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -45,6 +45,7 @@ spec:
           capabilities:
             drop:
               - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.