### PR TITLE
STOR-1805: Set SecurityContext for HyperShift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/client-go v0.29.1
 	k8s.io/component-base v0.29.1
 	k8s.io/klog/v2 v2.120.1
+	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 )
 
 require (
@@ -107,7 +108,6 @@ require (
 	k8s.io/kms v0.29.1 // indirect
 	k8s.io/kube-aggregator v0.29.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240126223410-2919ad4fcfec // indirect
-	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect


### PR DESCRIPTION
Set's the RunAsNonRoot to false and the RunAsUser to 1001 if the management cluster HyperShift is running on does not support SCC. This is needed for running HyperShift on non-OpenShift management cluster's such as AKS as part of [OCPSTRAT-460](https://issues.redhat.com/browse/OCPSTRAT-460).