### PR TITLE
Run all snapshot pods as explicit UID

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -25,6 +25,9 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        # For running on hosted control plane on non-OCP clusters, such as ARO.
+        # On OCP, SCC would inject non-root user automatically.
+        runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
       serviceAccount: csi-snapshot-controller

--- a/assets/rbac/webhook_scc_role.yaml
+++ b/assets/rbac/webhook_scc_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-snapshot-webhook-scc-role
+  namespace: ${CONTROLPLANE_NAMESPACE}
+rules:
+# We use epxlicit UID in the controller Deployment, see a comment in webhook_deployment.yaml.
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/assets/rbac/webhook_scc_rolebinding.yaml
+++ b/assets/rbac/webhook_scc_rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-webhook-scc-rolebinding
+  namespace: ${CONTROLPLANE_NAMESPACE}
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshot-webhook
+    namespace: ${CONTROLPLANE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-snapshot-webhook-scc-role

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -59,6 +59,9 @@ spec:
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
+        # For running on hosted control plane on non-OCP clusters, such as ARO.
+        # On OCP, `restricted` SCC would inject non-root user automatically.
+        runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
       nodeSelector:

--- a/manifests/05_operand_rbac.yaml
+++ b/manifests/05_operand_rbac.yaml
@@ -36,6 +36,11 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
+  # We use epxlicit UID in the controller Deployment, see a comment in csi_controller_deployment.yaml.
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["nonroot-v2"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
 
 ---
 kind: ClusterRoleBinding

--- a/manifests/05_operator_role-hypershift.yaml
+++ b/manifests/05_operator_role-hypershift.yaml
@@ -75,6 +75,27 @@ rules:
   - list
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
   - hypershift.openshift.io
   resources:
   - hostedcontrolplanes

--- a/manifests/05_operator_role.yaml
+++ b/manifests/05_operator_role.yaml
@@ -80,4 +80,24 @@ rules:
   verbs:
   - list
   - watch
-
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -191,6 +191,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		"CSISnapshotStaticResourceController",
 		namespacedAssetFunc,
 		[]string{
+			"rbac/webhook_scc_role.yaml",
+			"rbac/webhook_scc_rolebinding.yaml",
 			"serviceaccount.yaml",
 			"webhook_serviceaccount.yaml",
 			"webhook_service.yaml",


### PR DESCRIPTION
We want to be able to run OCP hosted control plane, including snapshot controller and webhook, on non-OCP Kubernetes, such as ARO.

In that Kubernetes there is no SCC that would inject a non-root UID to the Pod, so:

* Specify the UID explicitly, so it's not root on non-OCP Kubernetes.
* Allow the snapshot controller to use `nonroot` SCC, so it can actually use the fixed UID from the Deployment. 