### PR TITLE
Avoid deleting VolumeGroupSnapshot resources

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -184,7 +184,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"volumegroupsnapshotclasses.yaml",
 		},
 		func() bool { return volumeGroupSnapshotAPIEnabled },
-		func() bool { return !volumeGroupSnapshotAPIEnabled },
+		func() bool { return false },
 	)
 
 	controlPlaneStaticResourcesController := staticresourcecontroller.NewStaticResourceController(


### PR DESCRIPTION
Prior to this patch, OCP would always try to delete those resources in a default installation. This is unnecessary because those resources are only created when TechPreviewNoUpgrade feature set is enabled.

Once this feature set is enabled, it's not possible to go back to a default installation (i.e., to a state where those resources should not exist). This means that those resources don't ever need to be deleted.

CC @openshift/storage 