### PR TITLE
STOR-1573: Update manifests to v7.0.0

### DIFF
--- a/assets/volumesnapshotclasses.yaml
+++ b/assets/volumesnapshotclasses.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -65,6 +65,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           parameters:
             additionalProperties:
               type: string

--- a/assets/volumesnapshotcontents.yaml
+++ b/assets/volumesnapshotcontents.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/955"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -71,6 +71,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: spec defines properties of a VolumeSnapshotContent created
               by the underlying storage system. Required.
@@ -172,6 +174,7 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
             required:
             - deletionPolicy
             - driver
@@ -238,6 +241,10 @@ spec:
                   on the underlying storage system. If not specified, it indicates
                   that dynamic snapshot creation has either failed or it is still
                   in progress.
+                type: string
+              volumeGroupSnapshotHandle:
+                description: VolumeGroupSnapshotHandle is the CSI "group_snapshot_id"
+                  of a group snapshot on the underlying storage system.
                 type: string
             type: object
         required:

--- a/assets/volumesnapshots.yaml
+++ b/assets/volumesnapshots.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -74,6 +74,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: 'spec defines the desired characteristics of a snapshot requested
               by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
@@ -188,6 +190,10 @@ spec:
                   specified, it indicates that the size is unknown.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              volumeGroupSnapshotName:
+                description: VolumeGroupSnapshotName is the name of the VolumeGroupSnapshot
+                  of which this VolumeSnapshot is a part of.
+                type: string
             type: object
         required:
         - spec


### PR DESCRIPTION
Update CRDs in `/assets` according to CRDs in https://github.com/kubernetes-csi/external-snapshotter/tree/v7.0.0/client/config/crd

@openshift/storage 