### PR TITLE
[4.15] OCPBUGS-31599: create suitable role and roleBinding for csi-snapshot-webhook

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 )
 
-//go:embed *.yaml
+//go:embed *.yaml rbac/*.yaml
 var f embed.FS
 
 // ReadFile reads and returns the content of the named file.

--- a/assets/rbac/webhook_clusterrole.yaml
+++ b/assets/rbac/webhook_clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-snapshot-webhook-clusterrole
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list", "watch"]

--- a/assets/rbac/webhook_clusterrolebinding.yaml
+++ b/assets/rbac/webhook_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-webhook-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshot-webhook
+    namespace: ${CONTROLPLANE_NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-snapshot-webhook-clusterrole

--- a/assets/webhook_deployment.yaml
+++ b/assets/webhook_deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: csi-snapshot-webhook
     spec:
+      serviceAccount: csi-snapshot-webhook
       containers:
       - name: webhook
         image: ${OPERAND_IMAGE}

--- a/assets/webhook_serviceaccount.yaml
+++ b/assets/webhook_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshot-webhook
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/manifests/05_operator_clusterrole.yaml
+++ b/manifests/05_operator_clusterrole.yaml
@@ -59,3 +59,10 @@ rules:
   - validatingwebhookconfigurations
   verbs:
   - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - "*"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -134,6 +134,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		"CSISnapshotGuestStaticResourceController",
 		namespacedAssetFunc,
 		[]string{
+			"rbac/webhook_clusterrole.yaml",
+			"rbac/webhook_clusterrolebinding.yaml",
 			"volumesnapshots.yaml",
 			"volumesnapshotcontents.yaml",
 			"volumesnapshotclasses.yaml",
@@ -148,6 +150,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		namespacedAssetFunc,
 		[]string{
 			"serviceaccount.yaml",
+			"webhook_serviceaccount.yaml",
 			"webhook_service.yaml",
 		},
 		resourceapply.NewKubeClientHolder(controlPlaneKubeClient),


### PR DESCRIPTION
Manual backport of https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/202 to 4.15 -- but only the parts required to get the correct permissions for the webhook. We don't want any of the volumegroupsnapshot changes backported.

/cc @openshift/storage @bertinatto @Phaow
