### PR TITLE
STOR-1593: Update api extensions to upstream

### DIFF
--- a/assets/volumegroupsnapshotclasses.yaml
+++ b/assets/volumegroupsnapshotclasses.yaml
@@ -4,8 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io
 spec:
   group: groupsnapshot.storage.k8s.io
@@ -35,45 +34,56 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VolumeGroupSnapshotClass specifies parameters that a underlying
-          storage system uses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass
-          is used by specifying its name in a VolumeGroupSnapshot object. VolumeGroupSnapshotClasses
-          are non-namespaced.
+        description: |-
+          VolumeGroupSnapshotClass specifies parameters that a underlying storage system
+          uses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass
+          is used by specifying its name in a VolumeGroupSnapshot object.
+          VolumeGroupSnapshotClasses are non-namespaced.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           deletionPolicy:
-            description: DeletionPolicy determines whether a VolumeGroupSnapshotContent
-              created through the VolumeGroupSnapshotClass should be deleted when
-              its bound VolumeGroupSnapshot is deleted. Supported values are "Retain"
-              and "Delete". "Retain" means that the VolumeGroupSnapshotContent and
-              its physical group snapshot on underlying storage system are kept. "Delete"
-              means that the VolumeGroupSnapshotContent and its physical group snapshot
-              on underlying storage system are deleted. Required.
+            description: |-
+              DeletionPolicy determines whether a VolumeGroupSnapshotContent created
+              through the VolumeGroupSnapshotClass should be deleted when its bound
+              VolumeGroupSnapshot is deleted.
+              Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are kept.
+              "Delete" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are deleted.
+              Required.
             enum:
             - Delete
             - Retain
             type: string
           driver:
-            description: Driver is the name of the storage driver expected to handle
-              this VolumeGroupSnapshotClass. Required.
+            description: |-
+              Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.
+              Required.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           parameters:
             additionalProperties:
               type: string
-            description: Parameters is a key-value map with storage driver specific
-              parameters for creating group snapshots. These values are opaque to
-              Kubernetes and are passed directly to the driver.
+            description: |-
+              Parameters is a key-value map with storage driver specific parameters for
+              creating group snapshots.
+              These values are opaque to Kubernetes and are passed directly to the driver.
             type: object
         required:
         - deletionPolicy

--- a/assets/volumegroupsnapshotcontents.yaml
+++ b/assets/volumegroupsnapshotcontents.yaml
@@ -3,9 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/971"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1068"
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io
 spec:
   group: groupsnapshot.storage.k8s.io
@@ -57,71 +56,90 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VolumeGroupSnapshotContent represents the actual "on-disk" group
-          snapshot object in the underlying storage system
+        description: |-
+          VolumeGroupSnapshotContent represents the actual "on-disk" group snapshot object
+          in the underlying storage system
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: Spec defines properties of a VolumeGroupSnapshotContent created
-              by the underlying storage system. Required.
+            description: |-
+              Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.
+              Required.
             properties:
               deletionPolicy:
-                description: DeletionPolicy determines whether this VolumeGroupSnapshotContent
-                  and the physical group snapshot on the underlying storage system
-                  should be deleted when the bound VolumeGroupSnapshot is deleted.
-                  Supported values are "Retain" and "Delete". "Retain" means that
-                  the VolumeGroupSnapshotContent and its physical group snapshot on
-                  underlying storage system are kept. "Delete" means that the VolumeGroupSnapshotContent
-                  and its physical group snapshot on underlying storage system are
-                  deleted. For dynamically provisioned group snapshots, this field
-                  will automatically be filled in by the CSI snapshotter sidecar with
-                  the "DeletionPolicy" field defined in the corresponding VolumeGroupSnapshotClass.
-                  For pre-existing snapshots, users MUST specify this field when creating
-                  the VolumeGroupSnapshotContent object. Required.
+                description: |-
+                  DeletionPolicy determines whether this VolumeGroupSnapshotContent and the
+                  physical group snapshot on the underlying storage system should be deleted
+                  when the bound VolumeGroupSnapshot is deleted.
+                  Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are deleted.
+                  For dynamically provisioned group snapshots, this field will automatically
+                  be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field
+                  defined in the corresponding VolumeGroupSnapshotClass.
+                  For pre-existing snapshots, users MUST specify this field when creating the
+                  VolumeGroupSnapshotContent object.
+                  Required.
                 enum:
                 - Delete
                 - Retain
                 type: string
               driver:
-                description: Driver is the name of the CSI driver used to create the
-                  physical group snapshot on the underlying storage system. This MUST
-                  be the same as the name returned by the CSI GetPluginName() call
-                  for that driver. Required.
+                description: |-
+                  Driver is the name of the CSI driver used to create the physical group snapshot on
+                  the underlying storage system.
+                  This MUST be the same as the name returned by the CSI GetPluginName() call for
+                  that driver.
+                  Required.
                 type: string
               source:
-                description: Source specifies whether the snapshot is (or should be)
-                  dynamically provisioned or already exists, and just requires a Kubernetes
-                  object representation. This field is immutable after creation. Required.
+                description: |-
+                  Source specifies whether the snapshot is (or should be) dynamically provisioned
+                  or already exists, and just requires a Kubernetes object representation.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   groupSnapshotHandles:
-                    description: GroupSnapshotHandles specifies the CSI "group_snapshot_id"
-                      of a pre-existing group snapshot and a list of CSI "snapshot_id"
-                      of pre-existing snapshots on the underlying storage system for
-                      which a Kubernetes object representation was (or should be)
-                      created. This field is immutable.
+                    description: |-
+                      GroupSnapshotHandles specifies the CSI "group_snapshot_id" of a pre-existing
+                      group snapshot and a list of CSI "snapshot_id" of pre-existing snapshots
+                      on the underlying storage system for which a Kubernetes object
+                      representation was (or should be) created.
+                      This field is immutable.
                     properties:
                       volumeGroupSnapshotHandle:
-                        description: VolumeGroupSnapshotHandle specifies the CSI "group_snapshot_id"
-                          of a pre-existing group snapshot on the underlying storage
-                          system for which a Kubernetes object representation was
-                          (or should be) created. This field is immutable. Required.
+                        description: |-
+                          VolumeGroupSnapshotHandle specifies the CSI "group_snapshot_id" of a pre-existing
+                          group snapshot on the underlying storage system for which a Kubernetes object
+                          representation was (or should be) created.
+                          This field is immutable.
+                          Required.
                         type: string
                       volumeSnapshotHandles:
-                        description: VolumeSnapshotHandles is a list of CSI "snapshot_id"
-                          of pre-existing snapshots on the underlying storage system
-                          for which Kubernetes objects representation were (or should
-                          be) created. This field is immutable. Required.
+                        description: |-
+                          VolumeSnapshotHandles is a list of CSI "snapshot_id" of pre-existing
+                          snapshots on the underlying storage system for which Kubernetes objects
+                          representation were (or should be) created.
+                          This field is immutable.
+                          Required.
                         items:
                           type: string
                         type: array
@@ -129,70 +147,98 @@ spec:
                     - volumeGroupSnapshotHandle
                     - volumeSnapshotHandles
                     type: object
+                    x-kubernetes-validations:
+                    - message: groupSnapshotHandles is immutable
+                      rule: self == oldSelf
                   volumeHandles:
-                    description: VolumeHandles is a list of volume handles on the
-                      backend to be snapshotted together. It is specified for dynamic
-                      provisioning of the VolumeGroupSnapshot. This field is immutable.
+                    description: |-
+                      VolumeHandles is a list of volume handles on the backend to be snapshotted
+                      together. It is specified for dynamic provisioning of the VolumeGroupSnapshot.
+                      This field is immutable.
                     items:
                       type: string
                     type: array
+                    x-kubernetes-validations:
+                    - message: volumeHandles is immutable
+                      rule: self == oldSelf
                 type: object
-                oneOf:
-                - required: ["volumeHandles"]
-                - required: ["groupSnapshotHandles"]
+                x-kubernetes-validations:
+                - message: volumeHandles is required once set
+                  rule: '!has(oldSelf.volumeHandles) || has(self.volumeHandles)'
+                - message: groupSnapshotHandles is required once set
+                  rule: '!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)'
+                - message: exactly one of volumeHandles and groupSnapshotHandles must
+                    be set
+                  rule: (has(self.volumeHandles) && !has(self.groupSnapshotHandles))
+                    || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))
               volumeGroupSnapshotClassName:
-                description: VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass
-                  from which this group snapshot was (or will be) created. Note that
-                  after provisioning, the VolumeGroupSnapshotClass may be deleted
-                  or recreated with different set of values, and as such, should not
-                  be referenced post-snapshot creation. For dynamic provisioning,
-                  this field must be set. This field may be unset for pre-provisioned
-                  snapshots.
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from
+                  which this group snapshot was (or will be) created.
+                  Note that after provisioning, the VolumeGroupSnapshotClass may be deleted or
+                  recreated with different set of values, and as such, should not be referenced
+                  post-snapshot creation.
+                  For dynamic provisioning, this field must be set.
+                  This field may be unset for pre-provisioned snapshots.
                 type: string
               volumeGroupSnapshotRef:
-                description: VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot
-                  object to which this VolumeGroupSnapshotContent object is bound.
-                  VolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must
-                  reference to this VolumeGroupSnapshotContent's name for the bidirectional
-                  binding to be valid. For a pre-existing VolumeGroupSnapshotContent
-                  object, name and namespace of the VolumeGroupSnapshot object MUST
-                  be provided for binding to happen. This field is immutable after
-                  creation. Required.
+                description: |-
+                  VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this
+                  VolumeGroupSnapshotContent object is bound.
+                  VolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to
+                  this VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.
+                  For a pre-existing VolumeGroupSnapshotContent object, name and namespace of the
+                  VolumeGroupSnapshot object MUST be provided for binding to happen.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
+                    must be set
+                  rule: has(self.name) && has(self.__namespace__)
+                - message: volumeGroupSnapshotRef is immutable
+                  rule: self == oldSelf
             required:
             - deletionPolicy
             - driver
@@ -203,108 +249,82 @@ spec:
             description: status represents the current information of a group snapshot.
             properties:
               creationTime:
-                description: CreationTime is the timestamp when the point-in-time
-                  group snapshot is taken by the underlying storage system. If not
-                  specified, it indicates the creation time is unknown. If not specified,
-                  it means the readiness of a group snapshot is unknown. The format
-                  of this field is a Unix nanoseconds time encoded as an int64. On
-                  Unix, the command date +%s%N returns the current time in nanoseconds
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it indicates the creation time is unknown.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                  The format of this field is a Unix nanoseconds time encoded as an int64.
+                  On Unix, the command date +%s%N returns the current time in nanoseconds
                   since 1970-01-01 00:00:00 UTC.
                 format: int64
                 type: integer
               error:
-                description: Error is the last observed error during group snapshot
-                  creation, if any. Upon success after retry, this error field will
-                  be cleared.
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  Upon success after retry, this error field will be cleared.
                 properties:
                   message:
-                    description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
                     type: string
                   time:
                     description: time is the timestamp when the error was encountered.
                     format: date-time
                     type: string
                 type: object
+              pvVolumeSnapshotContentList:
+                description: |-
+                  PVVolumeSnapshotContentList is the list of pairs of PV and
+                  VolumeSnapshotContent for this group snapshot
+                  The maximum number of allowed snapshots in the group is 100.
+                items:
+                  description: |-
+                    PVVolumeSnapshotContentPair represent a pair of PV names and
+                    VolumeSnapshotContent names
+                  properties:
+                    persistentVolumeRef:
+                      description: PersistentVolumeRef is a reference to the persistent
+                        volume resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    volumeSnapshotContentRef:
+                      description: VolumeSnapshotContentRef is a reference to the
+                        volume snapshot content resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               readyToUse:
-                description: ReadyToUse indicates if all the individual snapshots
-                  in the group are ready to be used to restore a group of volumes.
-                  ReadyToUse becomes true when ReadyToUse of all individual snapshots
-                  become true.
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready to be
+                  used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
                 type: boolean
               volumeGroupSnapshotHandle:
-                description: VolumeGroupSnapshotHandle is a unique id returned by
-                  the CSI driver to identify the VolumeGroupSnapshot on the storage
-                  system. If a storage system does not provide such an id, the CSI
-                  driver can choose to return the VolumeGroupSnapshot name.
+                description: |-
+                  VolumeGroupSnapshotHandle is a unique id returned by the CSI driver
+                  to identify the VolumeGroupSnapshot on the storage system.
+                  If a storage system does not provide such an id, the
+                  CSI driver can choose to return the VolumeGroupSnapshot name.
                 type: string
-              volumeSnapshotContentRefList:
-                description: VolumeSnapshotContentRefList is the list of volume snapshot
-                  content references for this group snapshot. The maximum number of
-                  allowed snapshots in the group is 100.
-                items:
-                  description: "ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs. 1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
-                    usage help.  It is impossible to add specific help for individual
-                    usage.  In most embedded usages, there are particular restrictions
-                    like, \"must refer only to types A and B\" or \"UID not honored\"
-                    or \"name must be restricted\". Those cannot be well described
-                    when embedded. 3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen. 4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple and the version of the actual struct
-                    is irrelevant. 5. We cannot easily change it.  Because this type
-                    is embedded in many locations, updates to this type will affect
-                    numerous schemas.  Don't make new APIs embed an underspecified
-                    API type they do not control. \n Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    ."
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                      type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                      type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
             type: object
         required:
         - spec

--- a/assets/volumegroupsnapshots.yaml
+++ b/assets/volumegroupsnapshots.yaml
@@ -3,9 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/995"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1068"
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: volumegroupsnapshots.groupsnapshot.storage.k8s.io
 spec:
   group: groupsnapshot.storage.k8s.io
@@ -47,215 +46,223 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VolumeGroupSnapshot is a user's request for creating either a
-          point-in-time group snapshot or binding to a pre-existing group snapshot.
+        description: |-
+          VolumeGroupSnapshot is a user's request for creating either a point-in-time
+          group snapshot or binding to a pre-existing group snapshot.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: Spec defines the desired characteristics of a group snapshot
-              requested by a user. Required.
+            description: |-
+              Spec defines the desired characteristics of a group snapshot requested by a user.
+              Required.
             properties:
               source:
-                description: Source specifies where a group snapshot will be created
-                  from. This field is immutable after creation. Required.
+                description: |-
+                  Source specifies where a group snapshot will be created from.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   selector:
-                    description: Selector is a label query over persistent volume
-                      claims that are to be grouped together for snapshotting. This
-                      labelSelector will be used to match the label added to a PVC.
+                    description: |-
+                      Selector is a label query over persistent volume claims that are to be
+                      grouped together for snapshotting.
+                      This labelSelector will be used to match the label added to a PVC.
                       If the label is added or removed to a volume after a group snapshot
                       is created, the existing group snapshots won't be modified.
-                      Once a VolumeGroupSnapshotContent is created and the sidecar
-                      starts to process it, the volume list will not change with retries.
+                      Once a VolumeGroupSnapshotContent is created and the sidecar starts to process
+                      it, the volume list will not change with retries.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - key
                           - operator
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: selector is immutable
+                      rule: self == oldSelf
                   volumeGroupSnapshotContentName:
-                    description: VolumeGroupSnapshotContentName specifies the name
-                      of a pre-existing VolumeGroupSnapshotContent object representing
-                      an existing volume group snapshot. This field should be set
-                      if the volume group snapshot already exists and only needs a
-                      representation in Kubernetes. This field is immutable.
+                    description: |-
+                      VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent
+                      object representing an existing volume group snapshot.
+                      This field should be set if the volume group snapshot already exists and
+                      only needs a representation in Kubernetes.
+                      This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: volumeGroupSnapshotContentName is immutable
+                      rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: selector is required once set
+                  rule: '!has(oldSelf.selector) || has(self.selector)'
+                - message: volumeGroupSnapshotContentName is required once set
+                  rule: '!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)'
+                - message: exactly one of selector and volumeGroupSnapshotContentName
+                    must be set
+                  rule: (has(self.selector) && !has(self.volumeGroupSnapshotContentName))
+                    || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))
               volumeGroupSnapshotClassName:
-                description: VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass
-                  requested by the VolumeGroupSnapshot. VolumeGroupSnapshotClassName
-                  may be left nil to indicate that the default class will be used.
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass
+                  requested by the VolumeGroupSnapshot.
+                  VolumeGroupSnapshotClassName may be left nil to indicate that the default
+                  class will be used.
                   Empty string is not allowed for this field.
                 type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotClassName must not be the empty string
+                    when set
+                  rule: size(self) > 0
             required:
             - source
             type: object
           status:
-            description: Status represents the current information of a group snapshot.
-              Consumers must verify binding between VolumeGroupSnapshot and VolumeGroupSnapshotContent
-              objects is successful (by validating that both VolumeGroupSnapshot and
-              VolumeGroupSnapshotContent point to each other) before using this object.
+            description: |-
+              Status represents the current information of a group snapshot.
+              Consumers must verify binding between VolumeGroupSnapshot and
+              VolumeGroupSnapshotContent objects is successful (by validating that both
+              VolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before
+              using this object.
             properties:
               boundVolumeGroupSnapshotContentName:
-                description: 'BoundVolumeGroupSnapshotContentName is the name of the
-                  VolumeGroupSnapshotContent object to which this VolumeGroupSnapshot
-                  object intends to bind to. If not specified, it indicates that the
-                  VolumeGroupSnapshot object has not been successfully bound to a
-                  VolumeGroupSnapshotContent object yet. NOTE: To avoid possible security
-                  issues, consumers must verify binding between VolumeGroupSnapshot
-                  and VolumeGroupSnapshotContent objects is successful (by validating
-                  that both VolumeGroupSnapshot and VolumeGroupSnapshotContent point
-                  at each other) before using this object.'
+                description: |-
+                  BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent
+                  object to which this VolumeGroupSnapshot object intends to bind to.
+                  If not specified, it indicates that the VolumeGroupSnapshot object has not
+                  been successfully bound to a VolumeGroupSnapshotContent object yet.
+                  NOTE: To avoid possible security issues, consumers must verify binding between
+                  VolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful
+                  (by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+                  point at each other) before using this object.
                 type: string
               creationTime:
-                description: CreationTime is the timestamp when the point-in-time
-                  group snapshot is taken by the underlying storage system. If not
-                  specified, it may indicate that the creation time of the group snapshot
-                  is unknown. The format of this field is a Unix nanoseconds time
-                  encoded as an int64. On Unix, the command date +%s%N returns the
-                  current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it may indicate that the creation time of the group snapshot
+                  is unknown.
+                  The format of this field is a Unix nanoseconds time encoded as an int64.
+                  On Unix, the command date +%s%N returns the current time in nanoseconds
+                  since 1970-01-01 00:00:00 UTC.
                 format: date-time
                 type: string
               error:
-                description: Error is the last observed error during group snapshot
-                  creation, if any. This field could be helpful to upper level controllers
-                  (i.e., application controller) to decide whether they should continue
-                  on waiting for the group snapshot to be created based on the type
-                  of error reported. The snapshot controller will keep retrying when
-                  an error occurs during the group snapshot creation. Upon success,
-                  this error field will be cleared.
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  This field could be helpful to upper level controllers (i.e., application
+                  controller) to decide whether they should continue on waiting for the group
+                  snapshot to be created based on the type of error reported.
+                  The snapshot controller will keep retrying when an error occurs during the
+                  group snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
-                    description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
                     type: string
                   time:
                     description: time is the timestamp when the error was encountered.
                     format: date-time
                     type: string
                 type: object
-              readyToUse:
-                description: ReadyToUse indicates if all the individual snapshots
-                  in the group are ready to be used to restore a group of volumes.
-                  ReadyToUse becomes true when ReadyToUse of all individual snapshots
-                  become true. If not specified, it means the readiness of a group
-                  snapshot is unknown.
-                type: boolean
-              volumeSnapshotRefList:
-                description: VolumeSnapshotRefList is the list of volume snapshot
-                  references for this group snapshot. The maximum number of allowed
-                  snapshots in the group is 100.
+              pvcVolumeSnapshotRefList:
+                description: |-
+                  VolumeSnapshotRefList is the list of PVC and VolumeSnapshot pairs that
+                  is part of this group snapshot.
+                  The maximum number of allowed snapshots in the group is 100.
                 items:
-                  description: "ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs. 1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
-                    usage help.  It is impossible to add specific help for individual
-                    usage.  In most embedded usages, there are particular restrictions
-                    like, \"must refer only to types A and B\" or \"UID not honored\"
-                    or \"name must be restricted\". Those cannot be well described
-                    when embedded. 3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen. 4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple and the version of the actual struct
-                    is irrelevant. 5. We cannot easily change it.  Because this type
-                    is embedded in many locations, updates to this type will affect
-                    numerous schemas.  Don't make new APIs embed an underspecified
-                    API type they do not control. \n Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    ."
+                  description: PVCVolumeSnapshotPair defines a pair of a PVC reference
+                    and a Volume Snapshot Reference
                   properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                      type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                      type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
+                    persistentVolumeClaimRef:
+                      description: PersistentVolumeClaimRef is a reference to the
+                        PVC this pair is referring to
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    volumeSnapshotRef:
+                      description: VolumeSnapshotRef is a reference to the VolumeSnapshot
+                        this pair is referring to
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
                   type: object
-                  x-kubernetes-map-type: atomic
                 type: array
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready
+                  to be used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                type: boolean
             type: object
         required:
         - spec

--- a/assets/volumesnapshotclasses.yaml
+++ b/assets/volumesnapshotclasses.yaml
@@ -4,8 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
   group: snapshot.storage.k8s.io
@@ -34,44 +33,52 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: VolumeSnapshotClass specifies parameters that a underlying storage
-          system uses when creating a volume snapshot. A specific VolumeSnapshotClass
-          is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
-          are non-namespaced
+        description: |-
+          VolumeSnapshotClass specifies parameters that a underlying storage system uses when
+          creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its
+          name in a VolumeSnapshot object.
+          VolumeSnapshotClasses are non-namespaced
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           deletionPolicy:
-            description: deletionPolicy determines whether a VolumeSnapshotContent
-              created through the VolumeSnapshotClass should be deleted when its bound
-              VolumeSnapshot is deleted. Supported values are "Retain" and "Delete".
-              "Retain" means that the VolumeSnapshotContent and its physical snapshot
-              on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent
-              and its physical snapshot on underlying storage system are deleted.
+            description: |-
+              deletionPolicy determines whether a VolumeSnapshotContent created through
+              the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+              Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept.
+              "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
               Required.
             enum:
             - Delete
             - Retain
             type: string
           driver:
-            description: driver is the name of the storage driver that handles this
-              VolumeSnapshotClass. Required.
+            description: |-
+              driver is the name of the storage driver that handles this VolumeSnapshotClass.
+              Required.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           parameters:
             additionalProperties:
               type: string
-            description: parameters is a key-value map with storage driver specific
-              parameters for creating snapshots. These values are opaque to Kubernetes.
+            description: |-
+              parameters is a key-value map with storage driver specific parameters for creating snapshots.
+              These values are opaque to Kubernetes.
             type: object
         required:
         - deletionPolicy

--- a/assets/volumesnapshotcontents.yaml
+++ b/assets/volumesnapshotcontents.yaml
@@ -3,9 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/955"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
   group: snapshot.storage.k8s.io
@@ -48,7 +47,8 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
-    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent
+        object is bound.
       jsonPath: .spec.volumeSnapshotRef.namespace
       name: VolumeSnapshotNamespace
       type: string
@@ -58,154 +58,206 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: VolumeSnapshotContent represents the actual "on-disk" snapshot
-          object in the underlying storage system
+        description: |-
+          VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
+          underlying storage system
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: spec defines properties of a VolumeSnapshotContent created
-              by the underlying storage system. Required.
+            description: |-
+              spec defines properties of a VolumeSnapshotContent created by the underlying storage system.
+              Required.
             properties:
               deletionPolicy:
-                description: deletionPolicy determines whether this VolumeSnapshotContent
-                  and its physical snapshot on the underlying storage system should
-                  be deleted when its bound VolumeSnapshot is deleted. Supported values
-                  are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
-                  and its physical snapshot on underlying storage system are kept.
-                  "Delete" means that the VolumeSnapshotContent and its physical snapshot
-                  on underlying storage system are deleted. For dynamically provisioned
-                  snapshots, this field will automatically be filled in by the CSI
-                  snapshotter sidecar with the "DeletionPolicy" field defined in the
-                  corresponding VolumeSnapshotClass. For pre-existing snapshots, users
-                  MUST specify this field when creating the VolumeSnapshotContent
-                  object. Required.
+                description: |-
+                  deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on
+                  the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+                  Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
+                  For dynamically provisioned snapshots, this field will automatically be filled in by the
+                  CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding
+                  VolumeSnapshotClass.
+                  For pre-existing snapshots, users MUST specify this field when creating the
+                   VolumeSnapshotContent object.
+                  Required.
                 enum:
                 - Delete
                 - Retain
                 type: string
               driver:
-                description: driver is the name of the CSI driver used to create the
-                  physical snapshot on the underlying storage system. This MUST be
-                  the same as the name returned by the CSI GetPluginName() call for
-                  that driver. Required.
+                description: |-
+                  driver is the name of the CSI driver used to create the physical snapshot on
+                  the underlying storage system.
+                  This MUST be the same as the name returned by the CSI GetPluginName() call for
+                  that driver.
+                  Required.
                 type: string
               source:
-                description: source specifies whether the snapshot is (or should be)
-                  dynamically provisioned or already exists, and just requires a Kubernetes
-                  object representation. This field is immutable after creation. Required.
+                description: |-
+                  source specifies whether the snapshot is (or should be) dynamically provisioned
+                  or already exists, and just requires a Kubernetes object representation.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   snapshotHandle:
-                    description: snapshotHandle specifies the CSI "snapshot_id" of
-                      a pre-existing snapshot on the underlying storage system for
-                      which a Kubernetes object representation was (or should be)
-                      created. This field is immutable.
-                    type: string
-                  volumeHandle:
-                    description: volumeHandle specifies the CSI "volume_id" of the
-                      volume from which a snapshot should be dynamically taken from.
+                    description: |-
+                      snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on
+                      the underlying storage system for which a Kubernetes object representation
+                      was (or should be) created.
                       This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: snapshotHandle is immutable
+                      rule: self == oldSelf
+                  volumeHandle:
+                    description: |-
+                      volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
+                      should be dynamically taken from.
+                      This field is immutable.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: volumeHandle is immutable
+                      rule: self == oldSelf
                 type: object
-                oneOf:
-                - required: ["snapshotHandle"]
-                - required: ["volumeHandle"]
+                x-kubernetes-validations:
+                - message: volumeHandle is required once set
+                  rule: '!has(oldSelf.volumeHandle) || has(self.volumeHandle)'
+                - message: snapshotHandle is required once set
+                  rule: '!has(oldSelf.snapshotHandle) || has(self.snapshotHandle)'
+                - message: exactly one of volumeHandle and snapshotHandle must be
+                    set
+                  rule: (has(self.volumeHandle) && !has(self.snapshotHandle)) || (!has(self.volumeHandle)
+                    && has(self.snapshotHandle))
               sourceVolumeMode:
-                description: SourceVolumeMode is the mode of the volume whose snapshot
-                  is taken. Can be either “Filesystem” or “Block”. If not specified,
-                  it indicates the source volume's mode is unknown. This field is
-                  immutable. This field is an alpha field.
+                description: |-
+                  SourceVolumeMode is the mode of the volume whose snapshot is taken.
+                  Can be either “Filesystem” or “Block”.
+                  If not specified, it indicates the source volume's mode is unknown.
+                  This field is immutable.
+                  This field is an alpha field.
                 type: string
+                x-kubernetes-validations:
+                - message: sourceVolumeMode is immutable
+                  rule: self == oldSelf
               volumeSnapshotClassName:
-                description: name of the VolumeSnapshotClass from which this snapshot
-                  was (or will be) created. Note that after provisioning, the VolumeSnapshotClass
-                  may be deleted or recreated with different set of values, and as
-                  such, should not be referenced post-snapshot creation.
+                description: |-
+                  name of the VolumeSnapshotClass from which this snapshot was (or will be)
+                  created.
+                  Note that after provisioning, the VolumeSnapshotClass may be deleted or
+                  recreated with different set of values, and as such, should not be referenced
+                  post-snapshot creation.
                 type: string
               volumeSnapshotRef:
-                description: volumeSnapshotRef specifies the VolumeSnapshot object
-                  to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
-                  field must reference to this VolumeSnapshotContent's name for the
-                  bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
-                  object, name and namespace of the VolumeSnapshot object MUST be
-                  provided for binding to happen. This field is immutable after creation.
+                description: |-
+                  volumeSnapshotRef specifies the VolumeSnapshot object to which this
+                  VolumeSnapshotContent object is bound.
+                  VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to
+                  this VolumeSnapshotContent's name for the bidirectional binding to be valid.
+                  For a pre-existing VolumeSnapshotContent object, name and namespace of the
+                  VolumeSnapshot object MUST be provided for binding to happen.
+                  This field is immutable after creation.
                   Required.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: both spec.volumeSnapshotRef.name and spec.volumeSnapshotRef.namespace
+                    must be set
+                  rule: has(self.name) && has(self.__namespace__)
             required:
             - deletionPolicy
             - driver
             - source
             - volumeSnapshotRef
             type: object
+            x-kubernetes-validations:
+            - message: sourceVolumeMode is required once set
+              rule: '!has(oldSelf.sourceVolumeMode) || has(self.sourceVolumeMode)'
           status:
             description: status represents the current information of a snapshot.
             properties:
               creationTime:
-                description: creationTime is the timestamp when the point-in-time
-                  snapshot is taken by the underlying storage system. In dynamic snapshot
-                  creation case, this field will be filled in by the CSI snapshotter
-                  sidecar with the "creation_time" value returned from CSI "CreateSnapshot"
-                  gRPC call. For a pre-existing snapshot, this field will be filled
-                  with the "creation_time" value returned from the CSI "ListSnapshots"
-                  gRPC call if the driver supports it. If not specified, it indicates
-                  the creation time is unknown. The format of this field is a Unix
-                  nanoseconds time encoded as an int64. On Unix, the command `date
-                  +%s%N` returns the current time in nanoseconds since 1970-01-01
-                  00:00:00 UTC.
+                description: |-
+                  creationTime is the timestamp when the point-in-time snapshot is taken
+                  by the underlying storage system.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  CSI snapshotter sidecar with the "creation_time" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "creation_time"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  If not specified, it indicates the creation time is unknown.
+                  The format of this field is a Unix nanoseconds time encoded as an int64.
+                  On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                  since 1970-01-01 00:00:00 UTC.
                 format: int64
                 type: integer
               error:
-                description: error is the last observed error during snapshot creation,
-                  if any. Upon success after retry, this error field will be cleared.
+                description: |-
+                  error is the last observed error during snapshot creation, if any.
+                  Upon success after retry, this error field will be cleared.
                 properties:
                   message:
-                    description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
                     type: string
                   time:
                     description: time is the timestamp when the error was encountered.
@@ -213,38 +265,40 @@ spec:
                     type: string
                 type: object
               readyToUse:
-                description: readyToUse indicates if a snapshot is ready to be used
-                  to restore a volume. In dynamic snapshot creation case, this field
-                  will be filled in by the CSI snapshotter sidecar with the "ready_to_use"
-                  value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
-                  snapshot, this field will be filled with the "ready_to_use" value
-                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                  it, otherwise, this field will be set to "True". If not specified,
-                  it means the readiness of a snapshot is unknown.
+                description: |-
+                  readyToUse indicates if a snapshot is ready to be used to restore a volume.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  CSI snapshotter sidecar with the "ready_to_use" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "ready_to_use"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                  otherwise, this field will be set to "True".
+                  If not specified, it means the readiness of a snapshot is unknown.
                 type: boolean
               restoreSize:
-                description: restoreSize represents the complete size of the snapshot
-                  in bytes. In dynamic snapshot creation case, this field will be
-                  filled in by the CSI snapshotter sidecar with the "size_bytes" value
-                  returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
-                  snapshot, this field will be filled with the "size_bytes" value
-                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                  it. When restoring a volume from this snapshot, the size of the
-                  volume MUST NOT be smaller than the restoreSize if it is specified,
-                  otherwise the restoration will fail. If not specified, it indicates
-                  that the size is unknown.
+                description: |-
+                  restoreSize represents the complete size of the snapshot in bytes.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  CSI snapshotter sidecar with the "size_bytes" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "size_bytes"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  When restoring a volume from this snapshot, the size of the volume MUST NOT
+                  be smaller than the restoreSize if it is specified, otherwise the restoration will fail.
+                  If not specified, it indicates that the size is unknown.
                 format: int64
                 minimum: 0
                 type: integer
               snapshotHandle:
-                description: snapshotHandle is the CSI "snapshot_id" of a snapshot
-                  on the underlying storage system. If not specified, it indicates
-                  that dynamic snapshot creation has either failed or it is still
-                  in progress.
+                description: |-
+                  snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system.
+                  If not specified, it indicates that dynamic snapshot creation has either failed
+                  or it is still in progress.
                 type: string
               volumeGroupSnapshotHandle:
-                description: VolumeGroupSnapshotHandle is the CSI "group_snapshot_id"
-                  of a group snapshot on the underlying storage system.
+                description: |-
+                  VolumeGroupSnapshotHandle is the CSI "group_snapshot_id" of a group snapshot
+                  on the underlying storage system.
                 type: string
             type: object
         required:

--- a/assets/volumesnapshots.yaml
+++ b/assets/volumesnapshots.yaml
@@ -3,9 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
   group: snapshot.storage.k8s.io
@@ -61,105 +60,140 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: VolumeSnapshot is a user's request for either creating a point-in-time
+        description: |-
+          VolumeSnapshot is a user's request for either creating a point-in-time
           snapshot of a persistent volume, or binding to a pre-existing snapshot.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: 'spec defines the desired characteristics of a snapshot requested
-              by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
-              Required.'
+            description: |-
+              spec defines the desired characteristics of a snapshot requested by a user.
+              More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+              Required.
             properties:
               source:
-                description: source specifies where a snapshot will be created from.
-                  This field is immutable after creation. Required.
+                description: |-
+                  source specifies where a snapshot will be created from.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   persistentVolumeClaimName:
-                    description: persistentVolumeClaimName specifies the name of the
-                      PersistentVolumeClaim object representing the volume from which
-                      a snapshot should be created. This PVC is assumed to be in the
-                      same namespace as the VolumeSnapshot object. This field should
-                      be set if the snapshot does not exists, and needs to be created.
+                    description: |-
+                      persistentVolumeClaimName specifies the name of the PersistentVolumeClaim
+                      object representing the volume from which a snapshot should be created.
+                      This PVC is assumed to be in the same namespace as the VolumeSnapshot
+                      object.
+                      This field should be set if the snapshot does not exists, and needs to be
+                      created.
                       This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: persistentVolumeClaimName is immutable
+                      rule: self == oldSelf
                   volumeSnapshotContentName:
-                    description: volumeSnapshotContentName specifies the name of a
-                      pre-existing VolumeSnapshotContent object representing an existing
-                      volume snapshot. This field should be set if the snapshot already
-                      exists and only needs a representation in Kubernetes. This field
-                      is immutable.
+                    description: |-
+                      volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent
+                      object representing an existing volume snapshot.
+                      This field should be set if the snapshot already exists and only needs a representation in Kubernetes.
+                      This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: volumeSnapshotContentName is immutable
+                      rule: self == oldSelf
                 type: object
-                oneOf:
-                - required: ["persistentVolumeClaimName"]
-                - required: ["volumeSnapshotContentName"]
+                x-kubernetes-validations:
+                - message: persistentVolumeClaimName is required once set
+                  rule: '!has(oldSelf.persistentVolumeClaimName) || has(self.persistentVolumeClaimName)'
+                - message: volumeSnapshotContentName is required once set
+                  rule: '!has(oldSelf.volumeSnapshotContentName) || has(self.volumeSnapshotContentName)'
+                - message: exactly one of volumeSnapshotContentName and persistentVolumeClaimName
+                    must be set
+                  rule: (has(self.volumeSnapshotContentName) && !has(self.persistentVolumeClaimName))
+                    || (!has(self.volumeSnapshotContentName) && has(self.persistentVolumeClaimName))
               volumeSnapshotClassName:
-                description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
-                  requested by the VolumeSnapshot. VolumeSnapshotClassName may be
-                  left nil to indicate that the default SnapshotClass should be used.
-                  A given cluster may have multiple default Volume SnapshotClasses:
-                  one default per CSI Driver. If a VolumeSnapshot does not specify
-                  a SnapshotClass, VolumeSnapshotSource will be checked to figure
-                  out what the associated CSI Driver is, and the default VolumeSnapshotClass
-                  associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
-                  exist for a given CSI Driver and more than one have been marked
-                  as default, CreateSnapshot will fail and generate an event. Empty
-                  string is not allowed for this field.'
+                description: |-
+                  VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                  requested by the VolumeSnapshot.
+                  VolumeSnapshotClassName may be left nil to indicate that the default
+                  SnapshotClass should be used.
+                  A given cluster may have multiple default Volume SnapshotClasses: one
+                  default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass,
+                  VolumeSnapshotSource will be checked to figure out what the associated
+                  CSI Driver is, and the default VolumeSnapshotClass associated with that
+                  CSI Driver will be used. If more than one VolumeSnapshotClass exist for
+                  a given CSI Driver and more than one have been marked as default,
+                  CreateSnapshot will fail and generate an event.
+                  Empty string is not allowed for this field.
                 type: string
+                x-kubernetes-validations:
+                - message: volumeSnapshotClassName must not be the empty string when
+                    set
+                  rule: size(self) > 0
             required:
             - source
             type: object
           status:
-            description: status represents the current information of a snapshot.
-              Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent
-              objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent
-              point at each other) before using this object.
+            description: |-
+              status represents the current information of a snapshot.
+              Consumers must verify binding between VolumeSnapshot and
+              VolumeSnapshotContent objects is successful (by validating that both
+              VolumeSnapshot and VolumeSnapshotContent point at each other) before
+              using this object.
             properties:
               boundVolumeSnapshotContentName:
-                description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
-                  object to which this VolumeSnapshot object intends to bind to. If
-                  not specified, it indicates that the VolumeSnapshot object has not
-                  been successfully bound to a VolumeSnapshotContent object yet. NOTE:
-                  To avoid possible security issues, consumers must verify binding
-                  between VolumeSnapshot and VolumeSnapshotContent objects is successful
-                  (by validating that both VolumeSnapshot and VolumeSnapshotContent
-                  point at each other) before using this object.'
+                description: |-
+                  boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                  object to which this VolumeSnapshot object intends to bind to.
+                  If not specified, it indicates that the VolumeSnapshot object has not been
+                  successfully bound to a VolumeSnapshotContent object yet.
+                  NOTE: To avoid possible security issues, consumers must verify binding between
+                  VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that
+                  both VolumeSnapshot and VolumeSnapshotContent point at each other) before using
+                  this object.
                 type: string
               creationTime:
-                description: creationTime is the timestamp when the point-in-time
-                  snapshot is taken by the underlying storage system. In dynamic snapshot
-                  creation case, this field will be filled in by the snapshot controller
-                  with the "creation_time" value returned from CSI "CreateSnapshot"
-                  gRPC call. For a pre-existing snapshot, this field will be filled
-                  with the "creation_time" value returned from the CSI "ListSnapshots"
-                  gRPC call if the driver supports it. If not specified, it may indicate
-                  that the creation time of the snapshot is unknown.
+                description: |-
+                  creationTime is the timestamp when the point-in-time snapshot is taken
+                  by the underlying storage system.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  snapshot controller with the "creation_time" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "creation_time"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  If not specified, it may indicate that the creation time of the snapshot is unknown.
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation,
-                  if any. This field could be helpful to upper level controllers(i.e.,
-                  application controller) to decide whether they should continue on
-                  waiting for the snapshot to be created based on the type of error
-                  reported. The snapshot controller will keep retrying when an error
-                  occurs during the snapshot creation. Upon success, this error field
-                  will be cleared.
+                description: |-
+                  error is the last observed error during snapshot creation, if any.
+                  This field could be helpful to upper level controllers(i.e., application controller)
+                  to decide whether they should continue on waiting for the snapshot to be created
+                  based on the type of error reported.
+                  The snapshot controller will keep retrying when an error occurs during the
+                  snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
-                    description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
                     type: string
                   time:
                     description: time is the timestamp when the error was encountered.
@@ -167,32 +201,35 @@ spec:
                     type: string
                 type: object
               readyToUse:
-                description: readyToUse indicates if the snapshot is ready to be used
-                  to restore a volume. In dynamic snapshot creation case, this field
-                  will be filled in by the snapshot controller with the "ready_to_use"
-                  value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
-                  snapshot, this field will be filled with the "ready_to_use" value
-                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                  it, otherwise, this field will be set to "True". If not specified,
-                  it means the readiness of a snapshot is unknown.
+                description: |-
+                  readyToUse indicates if the snapshot is ready to be used to restore a volume.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  snapshot controller with the "ready_to_use" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "ready_to_use"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                  otherwise, this field will be set to "True".
+                  If not specified, it means the readiness of a snapshot is unknown.
                 type: boolean
               restoreSize:
                 type: string
-                description: restoreSize represents the minimum size of volume required
-                  to create a volume from this snapshot. In dynamic snapshot creation
-                  case, this field will be filled in by the snapshot controller with
-                  the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call.
-                  For a pre-existing snapshot, this field will be filled with the
-                  "size_bytes" value returned from the CSI "ListSnapshots" gRPC call
-                  if the driver supports it. When restoring a volume from this snapshot,
-                  the size of the volume MUST NOT be smaller than the restoreSize
-                  if it is specified, otherwise the restoration will fail. If not
-                  specified, it indicates that the size is unknown.
+                description: |-
+                  restoreSize represents the minimum size of volume required to create a volume
+                  from this snapshot.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  snapshot controller with the "size_bytes" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "size_bytes"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  When restoring a volume from this snapshot, the size of the volume MUST NOT
+                  be smaller than the restoreSize if it is specified, otherwise the restoration will fail.
+                  If not specified, it indicates that the size is unknown.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               volumeGroupSnapshotName:
-                description: VolumeGroupSnapshotName is the name of the VolumeGroupSnapshot
-                  of which this VolumeSnapshot is a part of.
+                description: |-
+                  VolumeGroupSnapshotName is the name of the VolumeGroupSnapshot of which this
+                  VolumeSnapshot is a part of.
                 type: string
             type: object
         required:

--- a/assets/webhook_config.yaml
+++ b/assets/webhook_config.yaml
@@ -19,7 +19,7 @@ webhooks:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["snapshot.storage.k8s.io"]
         apiVersions: ["v1beta1", "v1"]
-        resources: ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
+        resources: ["volumesnapshotclasses"]
     admissionReviewVersions:
       - v1
       - v1beta1
@@ -35,7 +35,7 @@ webhooks:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["groupsnapshot.storage.k8s.io"]
         apiVersions: ["v1alpha1"]
-        resources: ["volumegroupsnapshots", "volumegroupsnapshotcontents", "volumegroupsnapshotclasses"]
+        resources: ["volumegroupsnapshotclasses"]
     admissionReviewVersions:
       - v1
     sideEffects: None


### PR DESCRIPTION
Update api extensions to upstream which implemented way of validating sources instead of using webhook. 
This is change is needed by https://github.com/openshift/csi-external-snapshotter/pull/156.

@openshift/storage 