### PR TITLE
STOR-2126: Enable readOnlyFileSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # csi-snapshot-controller-operator
 
 The CSI snapshot controller operator is an
-[OpenShift ClusterOperator](https://github.com/openshift/enhancements/blob/master/enhancements/dev-guide/operators.md#what-is-an-openshift-clusteroperator).
+[OpenShift ClusterOperator](https://github.com/openshift/enhancements/blob/master/dev-guide/operators.md#what-is-an-openshift-clusteroperator).
 It installs and maintains the CSI Snapshot Controller, which is responsible for watching the VolumeSnapshot CRD objects and manages the creation and deletion lifecycle of volume snapshots.

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -31,9 +31,12 @@ spec:
           requests:
             memory: 65Mi
             cpu: 10m
+        volumeMounts:
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - ALL
@@ -54,6 +57,10 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
       priorityClassName: "system-cluster-critical"
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/profile-patches/hypershift/07_deployment.yaml-patch
+++ b/profile-patches/hypershift/07_deployment.yaml-patch
@@ -19,6 +19,12 @@
 - op: remove
   path: /spec/template/spec/priorityClassName
 
+# Remove changes for readOnlyRootFilesystem
+- op: replace
+  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
+  value:
+    false
+
 # Add guest-kubeconfig volume
 - op: add
   path: /spec/template/spec/volumes

--- a/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
@@ -6,3 +6,15 @@
     capability.openshift.io/name: CSISnapshot
 - op: remove
   path: /spec/template/spec/nodeSelector
+
+# Remove serving-cert volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts
+- op: remove
+  path: /spec/template/spec/volumes
+
+# Remove changes for readOnlyRootFilesystem
+- op: replace
+  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
+  value:
+    false


### PR DESCRIPTION
Enable readOnlyFileSystem in the operator for security concerns. 
Recommended for all containers running in kubernetes.