### PR TITLE
OCPBUGS-24588: bump library-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/openshift/api v0.0.0-20250224185818-544b3ca4e8f5
 	github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c
 	github.com/openshift/client-go v0.0.0-20250131180035-f7ec47e2d87a
-	github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c
+	github.com/openshift/library-go v0.0.0-20250228164547-bad2d1bf3a37
 	github.com/prometheus/client_golang v1.21.0
 	github.com/spf13/cobra v1.9.1
 	k8s.io/api v0.32.2

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c h1:6X
 github.com/openshift/build-machinery-go v0.0.0-20250102153059-e85a1a7ecb5c/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250131180035-f7ec47e2d87a h1:duO3JMrUOqVx50QhzxvDeOYIwTNOB8/EEuRLPyvAMBg=
 github.com/openshift/client-go v0.0.0-20250131180035-f7ec47e2d87a/go.mod h1:Qw3ThpzVZ0bfTILpBNYg4LGyjtNxfyCiGh/uDLOOTP8=
-github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c h1:lW/rlxNTLYbHBoB9NBLEykzGriHyc/s/52bTQRUgH9U=
-github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c/go.mod h1:GHwvopE5KXXCz4ULHp871sTPLLW+FB+hu/RIzlNwxx8=
+github.com/openshift/library-go v0.0.0-20250228164547-bad2d1bf3a37 h1:/YhxswjRkADbww682dqckHddV/AVfwQHFn/XTf2fjsk=
+github.com/openshift/library-go v0.0.0-20250228164547-bad2d1bf3a37/go.mod h1:GHwvopE5KXXCz4ULHp871sTPLLW+FB+hu/RIzlNwxx8=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/deploymentcontroller/deployment_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/deploymentcontroller/deployment_controller.go
@@ -299,12 +299,14 @@ func (c *DeploymentController) syncManaged(ctx context.Context, opSpec *opv1.Ope
 				WithStatus(opv1.ConditionTrue).
 				WithMessage(msg).
 				WithReason("Deploying")
+
+			// Degrade when operator is progressing too long.
+			// Only do this if we would continue to be in the Progressing state, otherwise, we'll never get out
+			if v1helpers.IsUpdatingTooLong(opStatus, c.instanceName+opv1.OperatorStatusTypeProgressing) {
+				return fmt.Errorf("Deployment was progressing too long")
+			}
 		}
 
-		// Degrade when operator is progressing too long.
-		if v1helpers.IsUpdatingTooLong(opStatus, c.instanceName+opv1.OperatorStatusTypeProgressing) {
-			return fmt.Errorf("Deployment was progressing too long")
-		}
 		status = status.WithConditions(progressingCondition)
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/apiregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/apiregistration.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+var (
+	apiRegisterScheme = runtime.NewScheme()
+	apiRegisterCodec  = serializer.NewCodecFactory(apiRegisterScheme)
+)
+
+func init() {
+	if err := apiregistrationv1.AddToScheme(apiRegisterScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadAPIServiceOrDie(objBytes []byte) *apiregistrationv1.APIService {
+	requiredObj, err := runtime.Decode(apiRegisterCodec.UniversalDecoder(apiregistrationv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*apiregistrationv1.APIService)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -281,7 +281,7 @@ github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/config/listers/config/v1alpha1
 github.com/openshift/client-go/operator/applyconfigurations/internal
 github.com/openshift/client-go/operator/applyconfigurations/operator/v1
-# github.com/openshift/library-go v0.0.0-20250218150059-017e5b6cf27c
+# github.com/openshift/library-go v0.0.0-20250228164547-bad2d1bf3a37
 ## explicit; go 1.23.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
To pull deployment controller fix:
https://github.com/openshift/library-go/pull/1940