### PR TITLE
OCPBUGS-62247: add all-egress label to deployments on HCP and IBM

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app: csi-snapshot-controller
         openshift.storage.network-policy.dns: allow
         openshift.storage.network-policy.api-server: allow
+        # Hypershift allows the API server port to be defined in
+        # hostedcluster.spec.networking.apiServer.port so in this case we add the
+        # all-egress network policy to allow reaching the server on any port.
+        openshift.storage.network-policy.all-egress: allow
     spec:
       securityContext:
         runAsNonRoot: true

--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -17,6 +17,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
+        openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow
         openshift.storage.network-policy.dns: allow
         openshift.storage.network-policy.operator-metrics: allow

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -22,6 +22,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
+        openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow
         openshift.storage.network-policy.dns: allow
         openshift.storage.network-policy.operator-metrics: allow

--- a/profile-patches/hypershift/07_deployment.yaml-patch
+++ b/profile-patches/hypershift/07_deployment.yaml-patch
@@ -43,3 +43,15 @@
   path: /spec/template/spec/containers/0/args/-
   value:
     "--guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig"
+
+# Hypershift allows the API server port to be defined in
+# hostedcluster.spec.networking.apiServer.port so in this case we add the
+# all-egress network policy to allow reaching the server on any port.
+- op: replace
+  path: /spec/template/metadata/labels
+  value:
+    app: csi-snapshot-controller-operator
+    openshift.storage.network-policy.all-egress: allow
+    openshift.storage.network-policy.api-server: allow
+    openshift.storage.network-policy.dns: allow
+    openshift.storage.network-policy.operator-metrics: allow

--- a/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
@@ -18,3 +18,15 @@
   path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
   value:
     false
+
+# Hypershift allows the API server port to be defined in
+# hostedcluster.spec.networking.apiServer.port so in this case we add the
+# all-egress network policy to allow reaching the server on any port.
+- op: replace
+  path: /spec/template/metadata/labels
+  value:
+    app: csi-snapshot-controller-operator
+    openshift.storage.network-policy.all-egress: allow
+    openshift.storage.network-policy.api-server: allow
+    openshift.storage.network-policy.dns: allow
+    openshift.storage.network-policy.operator-metrics: allow


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-62247
/cc @openshift/storage
see also: https://github.com/openshift/cluster-storage-operator/pull/621