### PR TITLE
STOR-2523: Add hypershift managed-by labels for csi-snapshot-controller-operator

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -17,6 +17,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
+        hypershift.openshift.io/managed-by: cluster-version-operator
         openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow
         openshift.storage.network-policy.dns: allow

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -22,6 +22,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
+        hypershift.openshift.io/managed-by: cluster-version-operator
         openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow
         openshift.storage.network-policy.dns: allow

--- a/profile-patches/hypershift/07_deployment.yaml-patch
+++ b/profile-patches/hypershift/07_deployment.yaml-patch
@@ -55,3 +55,4 @@
     openshift.storage.network-policy.api-server: allow
     openshift.storage.network-policy.dns: allow
     openshift.storage.network-policy.operator-metrics: allow
+    hypershift.openshift.io/managed-by: cluster-version-operator

--- a/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
@@ -30,3 +30,4 @@
     openshift.storage.network-policy.api-server: allow
     openshift.storage.network-policy.dns: allow
     openshift.storage.network-policy.operator-metrics: allow
+    hypershift.openshift.io/managed-by: cluster-version-operator


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-2523

> Any operand running on a container/Deployment management side must have a label "hypershift.openshift.io/managed-by: <operator-name>".