### PR TITLE
STOR-2560: Add readOnlyRootFilesystem to hypershift and ibm-cloud-managed

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -50,7 +50,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -54,7 +54,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:

--- a/profile-patches/hypershift/07_deployment.yaml-patch
+++ b/profile-patches/hypershift/07_deployment.yaml-patch
@@ -19,12 +19,6 @@
 - op: remove
   path: /spec/template/spec/priorityClassName
 
-# Remove changes for readOnlyRootFilesystem
-- op: replace
-  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
-  value:
-    false
-
 # Add guest-kubeconfig volume
 - op: add
   path: /spec/template/spec/volumes

--- a/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
@@ -13,12 +13,6 @@
 - op: remove
   path: /spec/template/spec/volumes
 
-# Remove changes for readOnlyRootFilesystem
-- op: replace
-  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
-  value:
-    false
-
 # Hypershift allows the API server port to be defined in
 # hostedcluster.spec.networking.apiServer.port so in this case we add the
 # all-egress network policy to allow reaching the server on any port.


### PR DESCRIPTION
`readOnlyRootFilesystem` should be enabled in all versions of OpenShift