### PR TITLE
STOR-2523: Add hypershift managed-by labels for `csi-snapshot-controller` operand

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 metadata:
   name: csi-snapshot-controller
   namespace: ${CONTROLPLANE_NAMESPACE}
+  labels:
+    hypershift.openshift.io/managed-by: csi-snapshot-controller-operator
 spec:
   serviceName: "csi-snapshot-controller"
   # Replicas for HyperShift. On standalone OCP it will be adjusted according to nr. of master nodes.


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-2523

> Any operand running on a container/Deployment management side must have a label "hypershift.openshift.io/managed-by: <operator-name>".