### PR TITLE
CNTRLPLANE-1544: manifests: Use restricted-v3 scc for the operator

### DIFF
--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: restricted-v3
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
@@ -55,6 +55,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: restricted-v3
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: csi-snapshot-controller-operator
@@ -56,6 +56,7 @@ spec:
             - ALL
           readOnlyRootFilesystem: false
         terminationMessagePolicy: FallbackToLogsOnError
+      hostUsers: false
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: restricted-v3
       labels:
         app: csi-snapshot-controller-operator
         openshift.storage.network-policy.dns: allow
@@ -77,6 +77,7 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: "NoSchedule"
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
This effectively enforces user namespaces.

I didn't really want to update the Hypershift manifest, but it cannot be skipped, it seems.