### PR TITLE
OCPBUGS-66390: Set client throttling parameters

### DIFF
--- a/assets/csi_controller_deployment.yaml
+++ b/assets/csi_controller_deployment.yaml
@@ -49,6 +49,8 @@ spec:
           args:
             - "--v=${LOG_LEVEL}"
             - "--leader-election=true"
+            - "-kube-api-qps=30"
+            - "-kube-api-burst=60"
             # Leader election values are from
             # https://github.com/openshift/library-go/blob/master/pkg/config/leaderelection/leaderelection.go
             - "--leader-election-lease-duration=137s"


### PR DESCRIPTION
See [OCPBUGS-66390](https://issues.redhat.com/browse/OCPBUGS-66390) for tests with various qps and burst values. 30 and 60 has shown to be the most fruitful - the controller will not be throttled, the CSI driver is the bottleneck in all snapshot operations.