### PR TITLE
STOR-2954: feat: have CVO inject the centralized TLS configuration into the operator's config

### DIFF
--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -11,6 +11,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: CSISnapshot
+    config.openshift.io/inject-tls: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/07_deployment-hypershift.yaml
+++ b/manifests/07_deployment-hypershift.yaml
@@ -26,6 +26,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: OPERAND_IMAGE
@@ -41,6 +45,10 @@ spec:
         image: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator:latest
         imagePullPolicy: IfNotPresent
         name: csi-snapshot-controller-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -53,6 +61,10 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: config
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
       securityContext:
@@ -61,6 +73,12 @@ spec:
           type: RuntimeDefault
       serviceAccountName: csi-snapshot-controller-operator
       volumes:
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+      - configMap:
+          name: csi-snapshot-controller-operator-config
+        name: config
       - name: guest-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -31,6 +31,10 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/origin-csi-snapshot-controller
@@ -45,6 +49,10 @@ spec:
         image: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator:latest
         imagePullPolicy: IfNotPresent
         name: csi-snapshot-controller-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -59,6 +67,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: config
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -81,3 +91,6 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+      - configMap:
+          name: csi-snapshot-controller-operator-config
+        name: config

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -30,6 +30,10 @@ spec:
       - name: csi-snapshot-controller-operator
         image: quay.io/openshift/origin-cluster-csi-snapshot-controller-operator:latest
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             memory: 65Mi
@@ -37,6 +41,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: config
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -46,6 +52,10 @@ spec:
         args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/origin-csi-snapshot-controller
@@ -62,6 +72,9 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+      - name: config
+        configMap:
+          name: csi-snapshot-controller-operator-config
       priorityClassName: "system-cluster-critical"
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/profile-patches/hypershift/07_deployment.yaml-patch
+++ b/profile-patches/hypershift/07_deployment.yaml-patch
@@ -19,18 +19,19 @@
 - op: remove
   path: /spec/template/spec/priorityClassName
 
-# Add guest-kubeconfig volume
+# Add guest-kubeconfig volume (append to existing volumes)
 - op: add
-  path: /spec/template/spec/volumes
+  path: /spec/template/spec/volumes/-
   value:
-    - name: guest-kubeconfig
-      secret:
-        secretName: service-network-admin-kubeconfig
+    name: guest-kubeconfig
+    secret:
+      secretName: service-network-admin-kubeconfig
+# Add guest-kubeconfig volumeMount (append to existing volumeMounts)
 - op: add
-  path: /spec/template/spec/containers/0/volumeMounts
+  path: /spec/template/spec/containers/0/volumeMounts/-
   value:
-    - name: guest-kubeconfig
-      mountPath: /etc/guest-kubeconfig
+    name: guest-kubeconfig
+    mountPath: /etc/guest-kubeconfig
 
 # Add cmdline args
 - op: add


### PR DESCRIPTION
Also, have the operator restart whenever the config changes.

wip-docs: https://github.com/openshift/enhancements/pull/2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator metrics endpoint (TCP 8443) exposed for monitoring.

* **Improvements**
  * TLS injection enabled for operator configuration.
  * Operator now reloads/restarts automatically when config or serving certificate files change.
  * Deployment templates/patches updated to append volume and mount entries, preserving existing lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->