### PR TITLE
OCPBUGS-87252: Fix group snapshots on HyperShift

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -281,6 +281,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			hyperShiftNodeSelectorHook(hcpInformer.Lister(), controlPlaneNamespace),
 			hyperShiftLabelsHook(hcpInformer.Lister(), controlPlaneNamespace),
 			hyperShiftSetSecurityContext(),
+			withVolumeGroupSnapshot(volumeGroupSnapshotAPIEnabled),
 		}
 
 	} else {


### PR DESCRIPTION
The group snapshots must be enabled in HyperShift too.

@openshift/storage 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Volume group snapshot functionality is now enabled for HyperShift deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->