### PR TITLE
STOR-2967: Update SnapshotMetadataService CRD asset from v1alpha1 to v1beta1

### DIFF
--- a/assets/snapshotmetadataservices.yaml
+++ b/assets/snapshotmetadataservices.yaml
@@ -17,7 +17,7 @@ spec:
     singular: snapshotmetadataservice
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: |-


### PR DESCRIPTION
## Summary

Update the `SnapshotMetadataService` CRD asset from `v1alpha1` to `v1beta1`, sourced from upstream [kubernetes-csi/external-snapshot-metadata v1.0.0](https://github.com/kubernetes-csi/external-snapshot-metadata/blob/v1.0.0/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml).

- Upstream v1.0.0 [removed v1alpha1 entirely](https://github.com/kubernetes-csi/external-snapshot-metadata/pull/215)
- The rebased sidecar ([STOR-2965](https://redhat.atlassian.net/browse/STOR-2965)) only speaks v1beta1, so the CRD must match

**No Go code changes** — the existing conditional deployment logic in `starter.go` already handles this CRD behind the `ExternalSnapshotMetadata` feature gate.

## Breaking Change

Existing `v1alpha1` SnapshotMetadataService CRs from DevPreview clusters are **not** preserved. DevPreview clusters cannot be upgraded — users must destroy and reprovision. This is expected for the DevPreview → TechPreview graduation.

## Dependencies

- Depends on **STOR-2966** (feature gate promotion to `TechPreviewNoUpgrade`) merging first
- Part of [STOR-2900](https://redhat.atlassian.net/browse/STOR-2900) epic (CBT Tech Preview)

## References

- Jira: https://redhat.atlassian.net/browse/STOR-2967
- Upstream CRD source: https://github.com/kubernetes-csi/external-snapshot-metadata/blob/v1.0.0/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
- v1alpha1 removal PR: https://github.com/kubernetes-csi/external-snapshot-metadata/pull/215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SnapshotMetadataService API version to beta, reflecting progression towards increased stability and production readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->