### PR TITLE
STOR-3005: Update group snapshot CRDs to offer only v1 API

### DIFF
--- a/assets/volumegroupsnapshotclasses.yaml
+++ b/assets/volumegroupsnapshotclasses.yaml
@@ -18,7 +18,7 @@ spec:
     singular: volumegroupsnapshotclass
   scope: Cluster
   versions:
-# Don't offer v1beta1 API in OCP, everyone must use v1beta2. We don't want to use conversion webhook in OCP.
+# Don't offer v1beta1 or v1beta2 API in OCP, everyone must use v1. We don't want to use conversion webhook in OCP.
 #  - additionalPrinterColumns:
 #    - jsonPath: .driver
 #      name: Driver
@@ -107,7 +107,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1beta2
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-

--- a/assets/volumegroupsnapshotcontents.yaml
+++ b/assets/volumegroupsnapshotcontents.yaml
@@ -28,7 +28,7 @@ spec:
   #          name: snapshot-conversion-webhook-service
   #          path: /convert
   versions:
-# Don't offer v1beta1 API in OCP, everyone must use v1beta2. We don't want to use conversion webhook in OCP.
+# Don't offer v1beta1 or v1beta2 API in OCP, everyone must use v1. We don't want to use conversion webhook in OCP.
 #  - additionalPrinterColumns:
 #    - description: Indicates if all the individual snapshots in the group are ready
 #        to be used to restore a group of volumes.
@@ -369,7 +369,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1beta2
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-
@@ -617,14 +617,10 @@ spec:
                   rule: self == oldSelf
               volumeSnapshotInfoList:
                 description: |-
-                  This field is introduced in v1beta2
-                  It is replacing VolumeSnapshotHandlePairList
                   VolumeSnapshotInfoList is a list of snapshot information returned by
-                  by the CSI driver to identify snapshots on the storage system.
+                  the CSI driver to identify snapshots on the storage system.
                 items:
-                  description: |-
-                    The VolumeSnapshotInfo struct is added in v1beta2
-                    VolumeSnapshotInfo contains information for a snapshot
+                  description: VolumeSnapshotInfo contains information for a snapshot
                   properties:
                     creationTime:
                       description: |-

--- a/assets/volumegroupsnapshots.yaml
+++ b/assets/volumegroupsnapshots.yaml
@@ -17,7 +17,7 @@ spec:
     singular: volumegroupsnapshot
   scope: Namespaced
   versions:
-# Don't offer v1beta1 API in OCP, everyone must use v1beta2. We don't want to use conversion webhook in OCP.
+# Don't offer v1beta1 or v1beta2 API in OCP, everyone must use v1. We don't want to use conversion webhook in OCP.
 #  - additionalPrinterColumns:
 #    - description: Indicates if all the individual snapshots in the group are ready
 #        to be used to restore a group of volumes.
@@ -265,7 +265,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1beta2
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-

--- a/assets/webhook_config.yaml
+++ b/assets/webhook_config.yaml
@@ -34,7 +34,7 @@ webhooks:
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["groupsnapshot.storage.k8s.io"]
-        apiVersions: ["v1alpha1"]
+        apiVersions: ["v1"]
         resources: ["volumegroupsnapshotclasses"]
     admissionReviewVersions:
       - v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Volume group snapshot APIs promoted to stable v1 version
  * Beta API versions (v1beta1, v1beta2) no longer supported
  * Webhook configurations updated to use v1 API version
  * Users must migrate existing configurations to v1 API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->