### PR TITLE
OCPBUGS-98444: Revert "STOR-2967: Update SnapshotMetadataService CRD asset from v1alpha1 to v1beta1"

### DIFF
--- a/assets/snapshotmetadataservices.yaml
+++ b/assets/snapshotmetadataservices.yaml
@@ -17,7 +17,7 @@ spec:
     singular: snapshotmetadataservice
   scope: Cluster
   versions:
-  - name: v1beta1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-98444

Reverts openshift/cluster-csi-snapshot-controller-operator#279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Snapshot Metadata Service resource definition to use the correct `v1alpha1` API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->